### PR TITLE
fix bug: when object is not being properly cleaned up

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -22,7 +22,11 @@ export default class Whisper extends Plugin {
 		this.addSettingTab(new WhisperSettingTab(this.app, this));
 	}
 
-	onunload() {}
+	onunload() {
+		if (this.recordingControls) {
+			this.recordingControls.close();
+		}
+	}
 
 	async loadSettings() {
 		this.settings = Object.assign(

--- a/src/RecordingControls.ts
+++ b/src/RecordingControls.ts
@@ -137,6 +137,9 @@ export class RecordingControls extends Modal {
 	}
 
 	close() {
+		if (this.recorder && this.recorder.state !== "inactive") {
+			this.recorder.stop();
+		}
 		super.close();
 		this.elapsedTime = 0;
 		this.recorder = null;


### PR DESCRIPTION
## Describe the bug and reproduce it

The first time user click the icon to open the recording screen and start recording, instead of selecting the Stop button, just close the window. 
When you click the icon again for the second time to open the recording interface, the recording will start automatically.

## Information

The issue occurs most likely because the `MediaRecorder` object is not being properly cleaned up when the modal is closed without stopping the recording.

## Changes Made

To fix this, I added a check for the state of the `MediaRecorder` when closing the modal and stop the recording if it's still active.

Also I added a check in ./main.ts, added `if (this.recordingControls)` check to `onunload()` to close the recording controls if it exists.