### PR TITLE
FR: add shortcut keys

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -13,6 +13,8 @@ export default class Whisper extends Plugin {
     recorder: NativeAudioRecorder
     audioHandler: AudioHandler;
     controls: Controls | null = null;
+    statusBarItem: HTMLElement | null = null;
+
 
     async onload() {
         this.settingsManager = new SettingsManager(this);
@@ -30,11 +32,54 @@ export default class Whisper extends Plugin {
         this.timer = new Timer()
         this.audioHandler = new AudioHandler(this);
         this.recorder = new NativeAudioRecorder()
-    }
 
+
+        this.statusBarItem = this.addStatusBarItem();
+        this.updateStatusBarItem(false);
+        this.addCommands();
+    }
+    updateStatusBarItem(recording: boolean) {
+        if (this.statusBarItem) {
+            this.statusBarItem.textContent = recording ? "Recording..." : "";
+            this.statusBarItem.style.color = recording ? "red" : "";
+        }
+    }
     onunload() {
         if (this.controls) {
             this.controls.close();
         }
+
+
+        if (this.statusBarItem) {
+            this.statusBarItem.remove();
+        }
+    }
+
+    addCommands() {
+        let recording = false;
+
+        this.addCommand({
+            id: "start-stop-recording",
+            name: "Start/Stop recording",
+            callback: async () => {
+                if (!recording) {
+                    recording = true;
+                    await this.recorder.startRecording();
+                } else {
+                    recording = false;
+                    const audioBlob = await this.recorder.stopRecording();
+                    // Use audioBlob to send or save the recorded audio as needed
+                    await this.audioHandler.sendAudioData(audioBlob);
+                }
+                this.updateStatusBarItem(recording);
+
+            },
+            hotkeys: [
+                {
+                    modifiers: ["Alt"],
+                    key: "`",
+                },
+            ],
+        });
     }
 }

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import Whisper from "main";
-import { Notice } from "obsidian";
+import { Notice, MarkdownView } from "obsidian";
 
 export class AudioHandler {
 	private plugin: Whisper;
@@ -45,16 +45,36 @@ export class AudioHandler {
 
 			console.log("Audio data sent successfully:", response.data.text);
 
-			// Create a new note with the transcribed text
-			const folderPath = this.plugin.settings.templateFile
-				? `${this.plugin.settings.templateFile}/`
-				: "";
-			const newNoteName = `${folderPath}Transcription-${new Date()
-				.toISOString()
-				.replace(/[:.]/g, "-")}.md`;
 
-			await this.plugin.app.vault.create(newNoteName, response.data.text);
-			await this.plugin.app.workspace.openLinkText(newNoteName, "", true);
+			// Determine if a new file should be created
+			const activeView = this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
+			const shouldCreateNewFile = this.plugin.settings.createNewFileAfterRecording || !activeView;
+
+
+			if (shouldCreateNewFile) {
+
+				// Create a new note with the transcribed text
+				const folderPath = this.plugin.settings.templateFile
+					? `${this.plugin.settings.templateFile}/`
+					: "";
+				const newNoteName = `${folderPath}Transcription-${new Date()
+					.toISOString()
+					.replace(/[:.]/g, "-")}.md`;
+
+				await this.plugin.app.vault.create(newNoteName, response.data.text);
+				await this.plugin.app.workspace.openLinkText(newNoteName, "", true);
+			} else {
+				// Insert the transcription at the cursor position
+				const editor = this.plugin.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
+				if (editor) {
+					const cursorPosition = editor.getCursor();
+					editor.replaceRange(response.data.text, cursorPosition);
+				}
+			}
+
+
+
+
 			new Notice("Audio parsed successfully.");
 		} catch (err) {
 			console.error("Error sending audio data:", err);

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -6,6 +6,7 @@ export interface WhisperSettings {
     model: string;
     language: string;
     templateFile: string;
+    createNewFileAfterRecording: boolean;
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -14,6 +15,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
     model: "whisper-1",
     language: "en",
     templateFile: "",
+    createNewFileAfterRecording: true,
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -1,16 +1,16 @@
 import Whisper from "main";
 import { App, PluginSettingTab, Setting } from "obsidian";
-import { SettingsManager} from "./SettingsManager";
+import { SettingsManager } from "./SettingsManager";
 
 export class WhisperSettingsTab extends PluginSettingTab {
-    private plugin: Whisper;
-    private settingsManager: SettingsManager;
+	private plugin: Whisper;
+	private settingsManager: SettingsManager;
 
-    constructor(app: App, plugin: Whisper) {
-        super(app, plugin);
-        this.plugin = plugin;
-        this.settingsManager = plugin.settingsManager;
-    }
+	constructor(app: App, plugin: Whisper) {
+		super(app, plugin);
+		this.plugin = plugin;
+		this.settingsManager = plugin.settingsManager;
+	}
 
 	display(): void {
 		let { containerEl } = this;
@@ -96,5 +96,18 @@ export class WhisperSettingsTab extends PluginSettingTab {
 
 				return text;
 			});
+		// Add a toggle for your new setting
+		new Setting(containerEl)
+			.setName("Create a new file after recording")
+			.setDesc("If enabled, the plugin will create a new file after recording. Otherwise, the transcription will be inserted at the cursor position.")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.createNewFileAfterRecording)
+					.onChange(async (value) => {
+						this.plugin.settings.createNewFileAfterRecording = value;
+						await this.settingsManager.saveSettings(this.plugin.settings);
+					})
+			);
 	}
+
 }


### PR DESCRIPTION
This resolves #6 
This also includes the changes that are needed to resolve #9 So the other pull request #11 can be closed.

- Added commands for toggle Record and Stop Recording. A shortcut can be assigned to toggle recording.
- This bypasses the recording modal
- A status bar indicator to show the status as `Whisper Idle` or `Recording` or `Processing`