### PR TITLE
Save audio file before sending to whisper

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -41,6 +41,15 @@ export class AudioHandler {
 		formData.append("language", this.plugin.settings.language);
 
 		try {
+			// If the saveAudioFile setting is true, save the audio file
+			if (this.plugin.settings.saveAudioFile) {
+				const arrayBuffer = await blob.arrayBuffer();
+				await this.plugin.app.vault.adapter.writeBinary(
+					audioFilePath,
+					new Uint8Array(arrayBuffer)
+				);
+				console.log("write to ", audioFilePath);
+			}
 			new Notice("Sending audio data:" + fileName);
 			const response = await axios.post(
 				this.plugin.settings.apiUrl,
@@ -60,16 +69,6 @@ export class AudioHandler {
 			}
 
 			console.log("Audio data sent successfully:", response.data.text);
-
-			// If the saveAudioFile setting is true, save the audio file
-			if (this.plugin.settings.saveAudioFile) {
-				const arrayBuffer = await blob.arrayBuffer();
-				await this.plugin.app.vault.adapter.writeBinary(
-					audioFilePath,
-					new Uint8Array(arrayBuffer)
-				);
-				console.log("write to ", audioFilePath);
-			}
 
 			// Determine if a new file should be created
 			const activeView =


### PR DESCRIPTION
Several times it happened to me that after recording a note, the plugin gave an error because I did not have a network connection or the whisper server was unavailable/error occurred.

My voice memo was lost because the plugin saves the audio only after successfully sending it to the server. And instead of just sending the voice memo audio file to the server, I have to remember what I said and record a new voice note. 

It would be more correct to save the audio file before sending it to the whisper server, which is what this pull request does.