### PR TITLE
Add prompting to the settings

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -39,6 +39,8 @@ export class AudioHandler {
 		formData.append("file", blob, fileName);
 		formData.append("model", this.plugin.settings.model);
 		formData.append("language", this.plugin.settings.language);
+		if (this.plugin.settings.prompt)
+			formData.append("prompt", this.plugin.settings.prompt);
 
 		try {
 			// If the saveAudioFile setting is true, save the audio file

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -15,6 +15,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	apiKey: "",
 	apiUrl: "https://api.openai.com/v1/audio/transcriptions",
 	model: "whisper-1",
+	prompt: "",
 	language: "en",
 	saveAudioFile: true,
 	saveAudioFilePath: "",

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -22,6 +22,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createApiKeySetting();
 		this.createApiUrlSetting();
 		this.createModelSetting();
+		this.createPromptSetting();
 		this.createLanguageSetting();
 		this.createSaveAudioFileToggleSetting();
 		this.createSaveAudioFilePathSetting();
@@ -99,6 +100,19 @@ export class WhisperSettingsTab extends PluginSettingTab {
 			this.plugin.settings.model,
 			async (value) => {
 				this.plugin.settings.model = value;
+				await this.settingsManager.saveSettings(this.plugin.settings);
+			}
+		);
+	}
+
+	private createPromptSetting(): void {
+		this.createTextSetting(
+			"Prompt",
+			"An optional text parameter to pass a dictionary of the correct spellings. It should match the Language.",
+			"ZyntriQix, Digique Plus, CynapseFive",
+			this.plugin.settings.prompt,
+			async (value) => {
+				this.plugin.settings.prompt = value;
 				await this.settingsManager.saveSettings(this.plugin.settings);
 			}
 		);


### PR DESCRIPTION
[Prompting](https://platform.openai.com/docs/guides/speech-to-text/prompting)
You can use a [prompt](https://platform.openai.com/docs/api-reference/audio/create#audio/create-prompt) to improve the quality of the transcripts generated by the Whisper API. The model will try to match the style of the prompt, so it will be more likely to use capitalization and punctuation if the prompt does too. However, the current prompting system is much more limited than our other language models and only provides limited control over the generated audio. Here are some examples of how prompting can help in different scenarios:


1. Prompts can be very helpful for correcting specific words or acronyms that the model often misrecognizes in the audio. For example, the following prompt improves the transcription of the words DALL·E and GPT-3, which were previously written as "GDP 3" and "DALI": "The transcript is about OpenAI which makes technology like DALL·E, GPT-3, and ChatGPT with the hope of one day building an AGI system that benefits all of humanity"
2. To preserve the context of a file that was split into segments, you can prompt the model with the transcript of the preceding segment. This will make the transcript more accurate, as the model will use the relevant information from the previous audio. The model will only consider the final 224 tokens of the prompt and ignore anything earlier. For multilingual inputs, Whisper uses a custom tokenizer. For English only inputs, it uses the standard GPT-2 tokenizer which are both accessible through the open source [Whisper Python package](https://github.com/openai/whisper/blob/main/whisper/tokenizer.py#L361).
3. Sometimes the model might skip punctuation in the transcript. You can avoid this by using a simple prompt that includes punctuation: "Hello, welcome to my lecture."
4. The model may also leave out common filler words in the audio. If you want to keep the filler words in your transcript, you can use a prompt that contains them: "Umm, let me think like, hmm... Okay, here's what I'm, like, thinking."
5. Some languages can be written in different ways, such as simplified or traditional Chinese. The model might not always use the writing style that you want for your transcript by default. You can improve this by using a prompt in your preferred writing style.