### PR TITLE
feat: option to pipe text-to-speech result to GPT for post processing

### DIFF
--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -8,6 +8,8 @@ export interface WhisperSettings {
 	language: string;
 	saveAudioFile: boolean;
 	saveAudioFilePath: string;
+	postProcessing: boolean;
+	postProcessingPrompt: string;
 	debugMode: boolean;
 	createNewFileAfterRecording: boolean;
 	createNewFileAfterRecordingPath: string;
@@ -21,6 +23,8 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	language: "en",
 	saveAudioFile: true,
 	saveAudioFilePath: "",
+	postProcessing: false,
+	postProcessingPrompt: "",
 	debugMode: false,
 	createNewFileAfterRecording: true,
 	createNewFileAfterRecordingPath: "",

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -8,6 +8,9 @@ export class WhisperSettingsTab extends PluginSettingTab {
 	private createNewFileInput: Setting;
 	private saveAudioFileInput: Setting;
 
+	private createPostProcessing: Setting;
+	private createPostProcessingPrompt: Setting;
+
 	constructor(app: App, plugin: Whisper) {
 		super(app, plugin);
 		this.plugin = plugin;
@@ -26,6 +29,8 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createLanguageSetting();
 		this.createSaveAudioFileToggleSetting();
 		this.createSaveAudioFilePathSetting();
+		this.createPostProcessingToggleSetting();
+		this.createPostProcessingPromptSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
 		this.createDebugModeToggleSetting();
@@ -172,6 +177,60 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					})
 			)
 			.setDisabled(!this.plugin.settings.saveAudioFile);
+	}
+
+	private createPostProcessingToggleSetting(): void {
+		this.createPostProcessing = new Setting(this.containerEl)
+			.setName("Enable Post processing")
+			.setDesc(
+				"Turn on to pipe result of the transcription through GPT to create the final document."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.postProcessing)
+					.onChange(async (value) => {
+						this.plugin.settings.postProcessing =
+							value;
+						if (!value) {
+							this.plugin.settings.postProcessingPrompt = "";
+						}
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+						this.createPostProcessingPrompt.setDisabled(!value);
+					});
+			});
+	}
+
+	private createPostProcessingPromptSetting(): void {
+		this.createPostProcessingPrompt = new Setting(this.containerEl)
+			.setName("Post Processing Prompt")
+			.setDesc(
+				"Instruct GPT on how to process the result of the transcription to create the final document. Make sure it matches the chosen language."
+			)
+			.addText((text) => {
+				text.setPlaceholder(
+					/*
+
+					Maybe this ?
+					
+					The following is a transcript of an audio note. Please format in markdown,
+					give it structure but keep it as accurate as possible. Then prepend with a summary section.
+
+					*/
+					  "Format as markdown."
+				    )
+					.setValue(
+						this.plugin.settings.postProcessingPrompt
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.postProcessingPrompt =
+							value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+			})
 	}
 
 	private createNewFileToggleSetting(): void {


### PR DESCRIPTION
New feature:

* Take the text result from whisper
* feed it to GPT4-o with a user defined prompt
* use that to create the final markdown document

so that one does not only get the verbatim text but a full fledged note that is usable for copy-pasting, integration in other notes or to keep as is in another place in the vault.

Example for a post processing prompt:

> Please respond in english. The following text is a transcript of a voice message. Format it in markdown, giving it a clear structure while keeping it as accurate as possible. Add a summary section at the beginning. If you come across to-do lists, format them as Markdown task lists with "[ ]". Avoid more than one level of nesting wherever possible. Finally, render the transcript exactly as spoken, with one sentence per line.

Settings:

![CleanShot 2024-11-19 at 12 52 16@2x](https://github.com/user-attachments/assets/009315d0-b8f6-4a9e-810e-5ab09d14e441)
