### PR TITLE
Add inline audio link/embed + type and position options

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -44,6 +44,7 @@ export class AudioHandler {
 		if (this.plugin.settings.prompt)
 			formData.append("prompt", this.plugin.settings.prompt);
 
+		let savedAudioFilePath: string | undefined;
 		try {
 			// If the saveAudioFile setting is true, save the audio file
 			if (this.plugin.settings.saveAudioFile) {
@@ -52,6 +53,7 @@ export class AudioHandler {
 					audioFilePath,
 					new Uint8Array(arrayBuffer)
 				);
+				savedAudioFilePath = audioFilePath;
 				new Notice("Audio saved successfully.");
 			}
 		} catch (err) {
@@ -79,11 +81,25 @@ export class AudioHandler {
 				this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
 			const shouldCreateNewFile =
 				this.plugin.settings.createNewFileAfterRecording || !activeView;
+			const transcriptionText = response.data?.text ?? "";
+			const audioEmbed = savedAudioFilePath
+				? `![[${savedAudioFilePath}]]`
+				: "";
+			const audioLink = savedAudioFilePath
+				? `[[${savedAudioFilePath}]]`
+				: "";
+			const inlineAudioReference =
+				this.plugin.settings.inlineAudioReferenceType === "link"
+					? audioLink
+					: audioEmbed;
 
 			if (shouldCreateNewFile) {
+				const noteContent = audioEmbed
+					? `${audioEmbed}\n${transcriptionText}`
+					: transcriptionText;
 				await this.plugin.app.vault.create(
 					noteFilePath,
-					`![[${audioFilePath}]]\n${response.data.text}`
+					noteContent
 				);
 				await this.plugin.app.workspace.openLinkText(
 					noteFilePath,
@@ -97,13 +113,25 @@ export class AudioHandler {
 						MarkdownView
 					)?.editor;
 				if (editor) {
+					const outputText =
+						this.plugin.settings.embedAudioInCurrentNote &&
+						inlineAudioReference
+							? this.plugin.settings.inlineAudioReferencePosition ===
+							  "below"
+								? `${transcriptionText}\n${inlineAudioReference}`
+								: `${inlineAudioReference}\n${transcriptionText}`
+							: transcriptionText;
 					const cursorPosition = editor.getCursor();
-					editor.replaceRange(response.data.text, cursorPosition);
+					editor.replaceRange(outputText, cursorPosition);
 
 					// Move the cursor to the end of the inserted text
+					const lines = outputText.split("\n");
 					const newPosition = {
-						line: cursorPosition.line,
-						ch: cursorPosition.ch + response.data.text.length,
+						line: cursorPosition.line + lines.length - 1,
+						ch:
+							lines.length === 1
+								? cursorPosition.ch + lines[0].length
+								: lines[lines.length - 1].length,
 					};
 					editor.setCursor(newPosition);
 				}

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -8,6 +8,9 @@ export interface WhisperSettings {
 	language: string;
 	saveAudioFile: boolean;
 	saveAudioFilePath: string;
+	embedAudioInCurrentNote: boolean;
+	inlineAudioReferenceType: "embed" | "link";
+	inlineAudioReferencePosition: "above" | "below";
 	debugMode: boolean;
 	createNewFileAfterRecording: boolean;
 	createNewFileAfterRecordingPath: string;
@@ -21,6 +24,9 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	language: "en",
 	saveAudioFile: true,
 	saveAudioFilePath: "",
+	embedAudioInCurrentNote: false,
+	inlineAudioReferenceType: "embed",
+	inlineAudioReferencePosition: "above",
 	debugMode: false,
 	createNewFileAfterRecording: true,
 	createNewFileAfterRecordingPath: "",

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -7,6 +7,9 @@ export class WhisperSettingsTab extends PluginSettingTab {
 	private settingsManager: SettingsManager;
 	private createNewFileInput: Setting;
 	private saveAudioFileInput: Setting;
+	private inlineAudioEmbedInput: Setting;
+	private inlineAudioReferenceTypeInput: Setting;
+	private inlineAudioReferencePositionInput: Setting;
 
 	constructor(app: App, plugin: Whisper) {
 		super(app, plugin);
@@ -26,6 +29,9 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createLanguageSetting();
 		this.createSaveAudioFileToggleSetting();
 		this.createSaveAudioFilePathSetting();
+		this.createInlineAudioEmbedToggleSetting();
+		this.createInlineAudioReferenceTypeSetting();
+		this.createInlineAudioReferencePositionSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
 		this.createDebugModeToggleSetting();
@@ -145,11 +151,19 @@ export class WhisperSettingsTab extends PluginSettingTab {
 						this.plugin.settings.saveAudioFile = value;
 						if (!value) {
 							this.plugin.settings.saveAudioFilePath = "";
+							this.plugin.settings.embedAudioInCurrentNote = false;
 						}
 						await this.settingsManager.saveSettings(
 							this.plugin.settings
 						);
 						this.saveAudioFileInput.setDisabled(!value);
+						this.inlineAudioEmbedInput.setDisabled(!value);
+						this.inlineAudioReferenceTypeInput.setDisabled(
+							!value || !this.plugin.settings.embedAudioInCurrentNote
+						);
+						this.inlineAudioReferencePositionInput.setDisabled(
+							!value || !this.plugin.settings.embedAudioInCurrentNote
+						);
 					})
 			);
 	}
@@ -172,6 +186,79 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					})
 			)
 			.setDisabled(!this.plugin.settings.saveAudioFile);
+	}
+
+	private createInlineAudioEmbedToggleSetting(): void {
+		this.inlineAudioEmbedInput = new Setting(this.containerEl)
+			.setName("Embed audio in current note")
+			.setDesc(
+				"When 'Save transcription' is off, insert the saved audio embed (![[...]]) with the transcription at your cursor."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.embedAudioInCurrentNote)
+					.onChange(async (value) => {
+						this.plugin.settings.embedAudioInCurrentNote = value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+						const disabled =
+							!this.plugin.settings.saveAudioFile || !value;
+						this.inlineAudioReferenceTypeInput.setDisabled(disabled);
+						this.inlineAudioReferencePositionInput.setDisabled(
+							disabled
+						);
+					});
+			})
+			.setDisabled(!this.plugin.settings.saveAudioFile);
+	}
+
+	private createInlineAudioReferenceTypeSetting(): void {
+		this.inlineAudioReferenceTypeInput = new Setting(this.containerEl)
+			.setName("Audio reference type")
+			.setDesc("Choose whether to insert an embed or a link.")
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOption("embed", "Embed (![[...]] )")
+					.addOption("link", "Link ([[...]] )")
+					.setValue(this.plugin.settings.inlineAudioReferenceType)
+					.onChange(async (value) => {
+						this.plugin.settings.inlineAudioReferenceType = value as
+							| "embed"
+							| "link";
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					})
+			)
+			.setDisabled(
+				!this.plugin.settings.saveAudioFile ||
+					!this.plugin.settings.embedAudioInCurrentNote
+			);
+	}
+
+	private createInlineAudioReferencePositionSetting(): void {
+		this.inlineAudioReferencePositionInput = new Setting(this.containerEl)
+			.setName("Audio reference position")
+			.setDesc("Insert audio reference above or below transcription text.")
+			.addDropdown((dropdown) =>
+				dropdown
+					.addOption("above", "Above transcription")
+					.addOption("below", "Below transcription")
+					.setValue(this.plugin.settings.inlineAudioReferencePosition)
+					.onChange(async (value) => {
+						this.plugin.settings.inlineAudioReferencePosition = value as
+							| "above"
+							| "below";
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					})
+			)
+			.setDisabled(
+				!this.plugin.settings.saveAudioFile ||
+					!this.plugin.settings.embedAudioInCurrentNote
+			);
 	}
 
 	private createNewFileToggleSetting(): void {


### PR DESCRIPTION
Added inline audio link/embed with type and position options requested from issue [#26](https://github.com/nikdanilov/whisper-obsidian-plugin/issues/26) 

Here's a short video and screenshot of new functionally and settings, lmk if any changes are needed

[Video](https://github.com/user-attachments/assets/4d3c0193-2d5c-48a1-b10e-ca2d9a5277d8)

Screenshot:
<img width="771" height="551" alt="image" src="https://github.com/user-attachments/assets/ba39895e-7fd2-4bc8-92cf-95deef138f83" />
