### PR TITLE
fix: don't link to nonexistent audio file when save is off

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -135,9 +135,12 @@ export class AudioHandler {
 				await this.ensureFolderExists(
 					this.plugin.settings.createNewFileAfterRecordingPath
 				);
+				const noteContent = this.plugin.settings.saveAudioFile
+					? `![[${audioFilePath}]]\n${response.data.text}`
+					: response.data.text;
 				await this.plugin.app.vault.create(
 					noteFilePath,
-					`![[${audioFilePath}]]\n${response.data.text}`
+					noteContent
 				);
 				await this.plugin.app.workspace.openLinkText(
 					noteFilePath,


### PR DESCRIPTION
Fixes #52

Only includes audio embed in note content when `saveAudioFile` is enabled. Previously created broken `![[...]]` links to audio files that were never saved.