### PR TITLE
feat: support custom API endpoints (local whisper, Azure)

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -30,7 +30,9 @@ export class AudioHandler {
 			new Notice(`Sending audio data size: ${blob.size / 1000} KB`);
 		}
 
-		if (!this.plugin.settings.apiKey) {
+		const isDefaultApi = this.plugin.settings.apiUrl ===
+			"https://api.openai.com/v1/audio/transcriptions";
+		if (isDefaultApi && !this.plugin.settings.apiKey) {
 			new Notice(
 				"API key is missing. Please add your API key in the settings."
 			);
@@ -69,7 +71,9 @@ export class AudioHandler {
 				{
 					headers: {
 						"Content-Type": "multipart/form-data",
-						Authorization: `Bearer ${this.plugin.settings.apiKey}`,
+						...(this.plugin.settings.apiKey
+							? { Authorization: `Bearer ${this.plugin.settings.apiKey}` }
+							: {}),
 					},
 				}
 			);


### PR DESCRIPTION
Fixes #2, fixes #74, fixes #61

- API key is only required when using the default OpenAI endpoint
- Authorization header is omitted when no API key is set
- Enables use with local whisper instances (e.g. whisper-asr-webservice) and Azure OpenAI