### PR TITLE
feat: independent paste-at-cursor and save-to-file toggles

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -125,13 +125,7 @@ export class AudioHandler {
 				}
 			);
 
-			// Determine if a new file should be created
-			const activeView =
-				this.plugin.app.workspace.getActiveViewOfType(MarkdownView);
-			const shouldCreateNewFile =
-				this.plugin.settings.createNewFileAfterRecording || !activeView;
-
-			if (shouldCreateNewFile) {
+			if (this.plugin.settings.createNewFileAfterRecording) {
 				await this.ensureFolderExists(
 					this.plugin.settings.createNewFileAfterRecordingPath
 				);
@@ -152,8 +146,9 @@ export class AudioHandler {
 					"",
 					true
 				);
-			} else {
-				// Insert the transcription at the cursor position
+			}
+
+			if (this.plugin.settings.pasteAtCursor) {
 				const editor =
 					this.plugin.app.workspace.getActiveViewOfType(
 						MarkdownView
@@ -162,7 +157,6 @@ export class AudioHandler {
 					const cursorPosition = editor.getCursor();
 					editor.replaceRange(response.data.text, cursorPosition);
 
-					// Move the cursor to the end of the inserted text
 					const newPosition = {
 						line: cursorPosition.line,
 						ch: cursorPosition.ch + response.data.text.length,

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -16,6 +16,7 @@ export interface WhisperSettings {
 	responseFormat: string;
 	sendCursorContext: boolean;
 	audioLinkStyle: "embed" | "link";
+	pasteAtCursor: boolean;
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -34,6 +35,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	responseFormat: "json",
 	sendCursorContext: false,
 	audioLinkStyle: "embed",
+	pasteAtCursor: false,
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -32,6 +32,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createResponseFormatSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
+		this.createPasteAtCursorSetting();
 		this.createSendCursorContextSetting();
 		this.createDebugModeToggleSetting();
 	}
@@ -328,6 +329,24 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.createNewFileAfterRecordingPath =
 							value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+			});
+	}
+
+	private createPasteAtCursorSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Paste at cursor")
+			.setDesc(
+				"Insert transcription at cursor position in the active note"
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.pasteAtCursor)
+					.onChange(async (value) => {
+						this.plugin.settings.pasteAtCursor = value;
 						await this.settingsManager.saveSettings(
 							this.plugin.settings
 						);

--- a/tests/AudioHandler.test.ts
+++ b/tests/AudioHandler.test.ts
@@ -176,16 +176,61 @@ describe("#65 — Silence/hallucination guard", () => {
 	});
 });
 
-describe("#64 — Paste and save simultaneously", () => {
-	it("setting allows both paste and save", () => {
-		const settings = {
-			...DEFAULT_SETTINGS,
+// Simulates the dispatch logic in AudioHandler.sendAudioData
+function getTranscriptionActions(settings: {
+	createNewFileAfterRecording: boolean;
+	pasteAtCursor: boolean;
+}): { createsFile: boolean; pastesAtCursor: boolean } {
+	return {
+		createsFile: settings.createNewFileAfterRecording,
+		pastesAtCursor: settings.pasteAtCursor,
+	};
+}
+
+describe("#64 — Paste and save as independent toggles", () => {
+	it("only creates file when createNewFileAfterRecording is on", () => {
+		const actions = getTranscriptionActions({
 			createNewFileAfterRecording: true,
-			pasteAtCursor: true, // new setting
-		};
-		// Both should be true simultaneously
-		expect(settings.createNewFileAfterRecording).toBe(true);
-		expect(settings.pasteAtCursor).toBe(true);
+			pasteAtCursor: false,
+		});
+		expect(actions.createsFile).toBe(true);
+		expect(actions.pastesAtCursor).toBe(false);
+	});
+
+	it("only pastes at cursor when pasteAtCursor is on", () => {
+		const actions = getTranscriptionActions({
+			createNewFileAfterRecording: false,
+			pasteAtCursor: true,
+		});
+		expect(actions.createsFile).toBe(false);
+		expect(actions.pastesAtCursor).toBe(true);
+	});
+
+	it("does both when both are on", () => {
+		const actions = getTranscriptionActions({
+			createNewFileAfterRecording: true,
+			pasteAtCursor: true,
+		});
+		expect(actions.createsFile).toBe(true);
+		expect(actions.pastesAtCursor).toBe(true);
+	});
+
+	it("does neither when both are off", () => {
+		const actions = getTranscriptionActions({
+			createNewFileAfterRecording: false,
+			pasteAtCursor: false,
+		});
+		expect(actions.createsFile).toBe(false);
+		expect(actions.pastesAtCursor).toBe(false);
+	});
+
+	it("default settings: creates file, does not paste", () => {
+		const actions = getTranscriptionActions({
+			createNewFileAfterRecording: DEFAULT_SETTINGS.createNewFileAfterRecording,
+			pasteAtCursor: (DEFAULT_SETTINGS as any).pasteAtCursor ?? false,
+		});
+		expect(actions.createsFile).toBe(true);
+		expect(actions.pastesAtCursor).toBe(false);
 	});
 });
 


### PR DESCRIPTION
Fixes #64

"Save transcription" and "Paste at cursor" are now two independent settings instead of a single either/or toggle. Both can be enabled at the same time.