### PR TITLE
feat: show notice when recording starts

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile } from "obsidian";
+import { Notice, Plugin, TFile } from "obsidian";
 import { Timer } from "src/Timer";
 import { Controls } from "src/Controls";
 import { AudioHandler } from "src/AudioHandler";
@@ -89,6 +89,7 @@ export default class Whisper extends Plugin {
 				if (this.statusBar.status !== RecordingStatus.Recording) {
 					this.statusBar.updateStatus(RecordingStatus.Recording);
 					await this.recorder.startRecording();
+					new Notice("Recording started");
 				} else {
 					this.statusBar.updateStatus(RecordingStatus.Processing);
 					const audioBlob = await this.recorder.stopRecording();

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -1,5 +1,5 @@
 import Whisper from "main";
-import { ButtonComponent, Modal } from "obsidian";
+import { ButtonComponent, Modal, Notice } from "obsidian";
 import { RecordingStatus } from "./StatusBar";
 
 export class Controls extends Modal {
@@ -67,6 +67,7 @@ export class Controls extends Modal {
 		this.plugin.statusBar.updateStatus(RecordingStatus.Recording);
 		await this.plugin.recorder.startRecording();
 		this.plugin.timer.start();
+		new Notice("Recording started");
 		this.resetGUI();
 	}
 


### PR DESCRIPTION
Fixes #41

Shows a "Recording started" notice from both the Controls UI and the keyboard shortcut.