### PR TITLE
fix: improve mobile audio compatibility

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -6,6 +6,7 @@ import { WhisperSettingsTab } from "src/WhisperSettingsTab";
 import { SettingsManager, WhisperSettings } from "src/SettingsManager";
 import { NativeAudioRecorder } from "src/AudioRecorder";
 import { RecordingStatus, StatusBar } from "src/StatusBar";
+import { getExtensionFromMimeType } from "src/utils";
 export default class Whisper extends Plugin {
 	settings: WhisperSettings;
 	settingsManager: SettingsManager;
@@ -93,9 +94,9 @@ export default class Whisper extends Plugin {
 				} else {
 					this.statusBar.updateStatus(RecordingStatus.Processing);
 					const audioBlob = await this.recorder.stopRecording();
-					const extension = this.recorder
-						.getMimeType()
-						?.split("/")[1];
+					const extension = getExtensionFromMimeType(
+						this.recorder.getMimeType()
+					);
 					const fileName = `${new Date()
 						.toISOString()
 						.replace(/[:.]/g, "-")}.${extension}`;

--- a/src/AudioRecorder.ts
+++ b/src/AudioRecorder.ts
@@ -7,7 +7,17 @@ export interface AudioRecorder {
 }
 
 function getSupportedMimeType(): string | undefined {
-	const mimeTypes = ["audio/webm", "audio/ogg", "audio/mp3", "audio/mp4"];
+	const mimeTypes = [
+		"audio/webm",
+		"audio/webm;codecs=opus",
+		"audio/ogg",
+		"audio/ogg;codecs=opus",
+		"audio/mp4",
+		"audio/mp4;codecs=mp4a.40.2",
+		"audio/aac",
+		"audio/wav",
+		"audio/mp3",
+	];
 
 	for (const mimeType of mimeTypes) {
 		if (MediaRecorder.isTypeSupported(mimeType)) {

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -1,6 +1,7 @@
 import Whisper from "main";
 import { ButtonComponent, Modal, Notice } from "obsidian";
 import { RecordingStatus } from "./StatusBar";
+import { getExtensionFromMimeType } from "./utils";
 
 export class Controls extends Modal {
 	private plugin: Whisper;
@@ -85,7 +86,9 @@ export class Controls extends Modal {
 		this.plugin.timer.reset();
 		this.resetGUI();
 
-		const extension = this.plugin.recorder.getMimeType()?.split("/")[1];
+		const extension = getExtensionFromMimeType(
+			this.plugin.recorder.getMimeType()
+		);
 		const fileName = `${new Date()
 			.toISOString()
 			.replace(/[:.]/g, "-")}.${extension}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,18 @@ export function getCursorContext(
 	return lines.slice(start, end).join("\n").trim();
 }
 
+export function getExtensionFromMimeType(mimeType: string | undefined): string {
+	if (!mimeType) return "webm";
+	const base = mimeType.split(";")[0];
+	const subtype = base.split("/")[1];
+	const extensionMap: Record<string, string> = {
+		"mp4a.40.2": "m4a",
+		"mpeg": "mp3",
+		"x-m4a": "m4a",
+	};
+	return extensionMap[subtype] || subtype;
+}
+
 export function getBaseFileName(filePath: string) {
 	// Extract the file name including extension
 	const fileName = filePath.substring(filePath.lastIndexOf("/") + 1);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getBaseFileName, getCursorContext } from "../src/utils";
+import { getBaseFileName, getCursorContext, getExtensionFromMimeType } from "../src/utils";
 
 describe("getBaseFileName", () => {
 	it("strips extension from simple filename", () => {
@@ -52,5 +52,27 @@ describe("getCursorContext", () => {
 		const editor = makeEditor("", 0);
 		const context = getCursorContext(editor, 5);
 		expect(context).toBe("");
+	});
+});
+
+describe("getExtensionFromMimeType", () => {
+	it("extracts extension from simple mime type", () => {
+		expect(getExtensionFromMimeType("audio/webm")).toBe("webm");
+	});
+
+	it("strips codecs parameter", () => {
+		expect(getExtensionFromMimeType("audio/webm;codecs=opus")).toBe("webm");
+	});
+
+	it("handles mp4 with codecs", () => {
+		expect(getExtensionFromMimeType("audio/mp4;codecs=mp4a.40.2")).toBe("mp4");
+	});
+
+	it("returns webm for undefined", () => {
+		expect(getExtensionFromMimeType(undefined)).toBe("webm");
+	});
+
+	it("handles audio/ogg", () => {
+		expect(getExtensionFromMimeType("audio/ogg;codecs=opus")).toBe("ogg");
 	});
 });


### PR DESCRIPTION
Fixes #76, fixes #73, fixes #60

- Expanded mime type list with codec variants (opus, AAC, WAV) for Android/iOS
- Fixed file extension extraction for mime types with codecs parameter (e.g. `audio/webm;codecs=opus` no longer produces `.webm;codecs=opus` extension)