### PR TITLE
feat: expose pause/resume and open controls as commands

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -141,5 +141,27 @@ export default class Whisper extends Plugin {
 				fileInput.click();
 			},
 		});
+
+		this.addCommand({
+			id: "pause-resume-recording",
+			name: "Pause/resume recording",
+			callback: async () => {
+				if (this.recorder.getRecordingState() === "recording" ||
+					this.recorder.getRecordingState() === "paused") {
+					await this.recorder.pauseRecording();
+				}
+			},
+		});
+
+		this.addCommand({
+			id: "open-recording-controls",
+			name: "Open recording controls",
+			callback: () => {
+				if (!this.controls) {
+					this.controls = new Controls(this);
+				}
+				this.controls.open();
+			},
+		});
 	}
 }


### PR DESCRIPTION
Fixes #77, fixes #29

Adds two new commands to the command palette:
- **Pause/resume recording** — toggles pause on an active recording
- **Open recording controls** — opens the recording modal

Both can be assigned custom hotkeys in Obsidian settings.