### PR TITLE
feat: toggle between embed and link for audio references

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -135,9 +135,14 @@ export class AudioHandler {
 				await this.ensureFolderExists(
 					this.plugin.settings.createNewFileAfterRecordingPath
 				);
-				const noteContent = this.plugin.settings.saveAudioFile
-					? `![[${audioFilePath}]]\n${response.data.text}`
-					: response.data.text;
+				let noteContent = response.data.text;
+				if (this.plugin.settings.saveAudioFile) {
+					const audioRef =
+						this.plugin.settings.audioLinkStyle === "link"
+							? `[[${audioFilePath}]]`
+							: `![[${audioFilePath}]]`;
+					noteContent = `${audioRef}\n${response.data.text}`;
+				}
 				await this.plugin.app.vault.create(
 					noteFilePath,
 					noteContent

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -15,6 +15,7 @@ export interface WhisperSettings {
 	temperature: number;
 	responseFormat: string;
 	sendCursorContext: boolean;
+	audioLinkStyle: "embed" | "link";
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -32,6 +33,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	temperature: 0,
 	responseFormat: "json",
 	sendCursorContext: false,
+	audioLinkStyle: "embed",
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -27,6 +27,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createAudioDeviceSetting();
 		this.createSaveAudioFileToggleSetting();
 		this.createSaveAudioFilePathSetting();
+		this.createAudioLinkStyleSetting();
 		this.createTemperatureSetting();
 		this.createResponseFormatSetting();
 		this.createNewFileToggleSetting();
@@ -236,6 +237,28 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					})
 			)
 			.setDisabled(!this.plugin.settings.saveAudioFile);
+	}
+
+	private createAudioLinkStyleSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Audio link style")
+			.setDesc(
+				"Choose how the audio file is referenced in notes: embed (playable) or link"
+			)
+			.addDropdown((dropdown) => {
+				dropdown
+					.addOption("embed", "Embed (![[file]])")
+					.addOption("link", "Link ([[file]])")
+					.setValue(this.plugin.settings.audioLinkStyle)
+					.onChange(async (value) => {
+						this.plugin.settings.audioLinkStyle = value as
+							| "embed"
+							| "link";
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+			});
 	}
 
 	private createTemperatureSetting(): void {

--- a/tests/__mocks__/obsidian.ts
+++ b/tests/__mocks__/obsidian.ts
@@ -46,6 +46,7 @@ export class Setting {
 	setDesc(_d: string) { return this; }
 	addText(_cb: any) { return this; }
 	addToggle(_cb: any) { return this; }
+	addDropdown(_cb: any) { return this; }
 	setDisabled(_d: boolean) { return this; }
 }
 


### PR DESCRIPTION
Fixes #26

New "Audio link style" dropdown in settings: choose between `![[file]]` (embed, playable inline) or `[[file]]` (link only).