### PR TITLE
feat: accept video files for upload/transcription

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -120,7 +120,7 @@ export default class Whisper extends Plugin {
 				// Create an input element for file selection
 				const fileInput = document.createElement("input");
 				fileInput.type = "file";
-				fileInput.accept = "audio/*"; // Accept only audio files
+				fileInput.accept = "audio/*,video/*,.mp4,.m4a,.wav,.webm,.ogg,.mp3";
 
 				// Handle file selection
 				fileInput.onchange = async (event) => {


### PR DESCRIPTION
Fixes #63

File picker now accepts video files (mp4, etc.) in addition to audio. Whisper API handles both.