### PR TITLE
feat: option to ignore original filename on upload

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -127,7 +127,13 @@ export default class Whisper extends Plugin {
 					const files = (event.target as HTMLInputElement).files;
 					if (files && files.length > 0) {
 						const file = files[0];
-						const fileName = file.name;
+						let fileName = file.name;
+						if (this.settings.ignoreUploadFilename) {
+							const extension = file.name.split(".").pop();
+							fileName = `${new Date()
+								.toISOString()
+								.replace(/[:.]/g, "-")}.${extension}`;
+						}
 						const audioBlob = file.slice(0, file.size, file.type);
 						// Use audioBlob to send or save the uploaded audio as needed
 						await this.audioHandler.sendAudioData(

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -17,6 +17,7 @@ export interface WhisperSettings {
 	sendCursorContext: boolean;
 	audioLinkStyle: "embed" | "link";
 	pasteAtCursor: boolean;
+	ignoreUploadFilename: boolean;
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -36,6 +37,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	sendCursorContext: false,
 	audioLinkStyle: "embed",
 	pasteAtCursor: false,
+	ignoreUploadFilename: false,
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -34,6 +34,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createNewFilePathSetting();
 		this.createPasteAtCursorSetting();
 		this.createSendCursorContextSetting();
+		this.createIgnoreUploadFilenameSetting();
 		this.createDebugModeToggleSetting();
 	}
 
@@ -365,6 +366,24 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.sendCursorContext)
 					.onChange(async (value) => {
 						this.plugin.settings.sendCursorContext = value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+			});
+	}
+
+	private createIgnoreUploadFilenameSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Ignore upload filename")
+			.setDesc(
+				"Use a timestamp-based filename instead of the original file name when uploading"
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.ignoreUploadFilename)
+					.onChange(async (value) => {
+						this.plugin.settings.ignoreUploadFilename = value;
 						await this.settingsManager.saveSettings(
 							this.plugin.settings
 						);


### PR DESCRIPTION
Fixes #68

New toggle "Ignore upload filename" — when enabled, uploaded files get a timestamp-based name instead of keeping the original filename.