### PR TITLE
feat: send cursor context as Whisper prompt

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 import Whisper from "main";
 import { Notice, MarkdownView } from "obsidian";
-import { getBaseFileName } from "./utils";
+import { getBaseFileName, getCursorContext } from "./utils";
 
 export class AudioHandler {
 	private plugin: Whisper;
@@ -65,8 +65,20 @@ export class AudioHandler {
 		) {
 			formData.append("language", this.plugin.settings.language);
 		}
-		if (this.plugin.settings.prompt)
-			formData.append("prompt", this.plugin.settings.prompt);
+
+		let prompt = this.plugin.settings.prompt || "";
+		if (this.plugin.settings.sendCursorContext) {
+			const editor =
+				this.plugin.app.workspace.getActiveViewOfType(
+					MarkdownView
+				)?.editor;
+			if (editor) {
+				const context = getCursorContext(editor);
+				prompt = prompt ? `${prompt}\n${context}` : context;
+			}
+		}
+		if (prompt) formData.append("prompt", prompt);
+
 		if (this.plugin.settings.temperature !== 0)
 			formData.append(
 				"temperature",

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -14,6 +14,7 @@ export interface WhisperSettings {
 	audioDeviceId: string;
 	temperature: number;
 	responseFormat: string;
+	sendCursorContext: boolean;
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -30,6 +31,7 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	audioDeviceId: "default",
 	temperature: 0,
 	responseFormat: "json",
+	sendCursorContext: false,
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -31,6 +31,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createResponseFormatSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
+		this.createSendCursorContextSetting();
 		this.createDebugModeToggleSetting();
 	}
 
@@ -304,6 +305,24 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						this.plugin.settings.createNewFileAfterRecordingPath =
 							value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+			});
+	}
+
+	private createSendCursorContextSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Send cursor context")
+			.setDesc(
+				"Send text around the cursor as context to Whisper for better transcription accuracy"
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.sendCursorContext)
+					.onChange(async (value) => {
+						this.plugin.settings.sendCursorContext = value;
 						await this.settingsManager.saveSettings(
 							this.plugin.settings
 						);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,14 @@
+export function getCursorContext(
+	editor: { getValue: () => string; getCursor: () => { line: number } },
+	contextLines: number = 5
+): string {
+	const lines = editor.getValue().split("\n");
+	const cursorLine = editor.getCursor().line;
+	const start = Math.max(0, cursorLine - contextLines);
+	const end = Math.min(lines.length, cursorLine + contextLines + 1);
+	return lines.slice(start, end).join("\n").trim();
+}
+
 export function getBaseFileName(filePath: string) {
 	// Extract the file name including extension
 	const fileName = filePath.substring(filePath.lastIndexOf("/") + 1);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getBaseFileName } from "../src/utils";
+import { getBaseFileName, getCursorContext } from "../src/utils";
 
 describe("getBaseFileName", () => {
 	it("strips extension from simple filename", () => {
@@ -18,5 +18,39 @@ describe("getBaseFileName", () => {
 
 	it("returns empty string for file with no base name", () => {
 		expect(getBaseFileName(".hidden")).toBe("");
+	});
+});
+
+describe("getCursorContext", () => {
+	const makeEditor = (text: string, cursorLine: number) => ({
+		getValue: () => text,
+		getCursor: () => ({ line: cursorLine }),
+	});
+
+	it("extracts lines around cursor", () => {
+		const text = "line0\nline1\nline2\nline3\nline4\nline5\nline6";
+		const editor = makeEditor(text, 3);
+		const context = getCursorContext(editor, 2);
+		expect(context).toBe("line1\nline2\nline3\nline4\nline5");
+	});
+
+	it("handles cursor at start of document", () => {
+		const text = "first\nsecond\nthird";
+		const editor = makeEditor(text, 0);
+		const context = getCursorContext(editor, 2);
+		expect(context).toBe("first\nsecond\nthird");
+	});
+
+	it("handles cursor at end of document", () => {
+		const text = "first\nsecond\nthird";
+		const editor = makeEditor(text, 2);
+		const context = getCursorContext(editor, 1);
+		expect(context).toBe("second\nthird");
+	});
+
+	it("returns empty string for empty document", () => {
+		const editor = makeEditor("", 0);
+		const context = getCursorContext(editor, 5);
+		expect(context).toBe("");
 	});
 });


### PR DESCRIPTION
Fixes #71

New "Send cursor context" setting. When enabled, text around the cursor is appended to the Whisper prompt parameter, giving the API context for more accurate transcription.