### PR TITLE
feat: expose temperature and response_format settings

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -67,6 +67,16 @@ export class AudioHandler {
 		}
 		if (this.plugin.settings.prompt)
 			formData.append("prompt", this.plugin.settings.prompt);
+		if (this.plugin.settings.temperature !== 0)
+			formData.append(
+				"temperature",
+				String(this.plugin.settings.temperature)
+			);
+		if (this.plugin.settings.responseFormat !== "json")
+			formData.append(
+				"response_format",
+				this.plugin.settings.responseFormat
+			);
 
 		try {
 			// If the saveAudioFile setting is true, save the audio file

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -12,6 +12,8 @@ export interface WhisperSettings {
 	createNewFileAfterRecording: boolean;
 	createNewFileAfterRecordingPath: string;
 	audioDeviceId: string;
+	temperature: number;
+	responseFormat: string;
 }
 
 export const DEFAULT_SETTINGS: WhisperSettings = {
@@ -26,6 +28,8 @@ export const DEFAULT_SETTINGS: WhisperSettings = {
 	createNewFileAfterRecording: true,
 	createNewFileAfterRecordingPath: "",
 	audioDeviceId: "default",
+	temperature: 0,
+	responseFormat: "json",
 };
 
 export class SettingsManager {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -27,6 +27,8 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createAudioDeviceSetting();
 		this.createSaveAudioFileToggleSetting();
 		this.createSaveAudioFilePathSetting();
+		this.createTemperatureSetting();
+		this.createResponseFormatSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
 		this.createDebugModeToggleSetting();
@@ -233,6 +235,35 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					})
 			)
 			.setDisabled(!this.plugin.settings.saveAudioFile);
+	}
+
+	private createTemperatureSetting(): void {
+		this.createTextSetting(
+			"Temperature",
+			"Sampling temperature (0 to 1). Higher values produce more random output.",
+			"0",
+			String(this.plugin.settings.temperature),
+			async (value) => {
+				const num = parseFloat(value);
+				this.plugin.settings.temperature = isNaN(num)
+					? 0
+					: Math.max(0, Math.min(1, num));
+				await this.settingsManager.saveSettings(this.plugin.settings);
+			}
+		);
+	}
+
+	private createResponseFormatSetting(): void {
+		this.createTextSetting(
+			"Response format",
+			"Output format: json, text, srt, verbose_json, or vtt",
+			"json",
+			this.plugin.settings.responseFormat,
+			async (value) => {
+				this.plugin.settings.responseFormat = value;
+				await this.settingsManager.saveSettings(this.plugin.settings);
+			}
+		);
 	}
 
 	private createNewFileToggleSetting(): void {


### PR DESCRIPTION
Fixes #35

Adds `temperature` (0-1) and `response_format` (json, text, srt, verbose_json, vtt) to plugin settings. Only sent to the API when non-default.