### PR TITLE
fix: recording controls UX — show/hide buttons, paused state

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -20,7 +20,7 @@ export default class Whisper extends Plugin {
 		this.settingsManager = new SettingsManager(this);
 		this.settings = await this.settingsManager.loadSettings();
 
-		this.addRibbonIcon("activity", "Open recording controls", (evt) => {
+		this.addRibbonIcon("mic", "Open recording controls", (evt) => {
 			if (!this.controls) {
 				this.controls = new Controls(this);
 			}
@@ -80,7 +80,8 @@ export default class Whisper extends Plugin {
 			id: "start-stop-recording",
 			name: "Start/stop recording",
 			callback: async () => {
-				if (this.statusBar.status !== RecordingStatus.Recording) {
+				if (this.statusBar.status !== RecordingStatus.Recording &&
+					this.statusBar.status !== RecordingStatus.Paused) {
 					this.statusBar.updateStatus(RecordingStatus.Recording);
 					await this.recorder.startRecording();
 					new Notice("Recording...");
@@ -145,9 +146,15 @@ export default class Whisper extends Plugin {
 			id: "pause-resume-recording",
 			name: "Pause/resume recording",
 			callback: async () => {
-				if (this.recorder.getRecordingState() === "recording" ||
-					this.recorder.getRecordingState() === "paused") {
+				const state = this.recorder.getRecordingState();
+				if (state === "recording") {
 					await this.recorder.pauseRecording();
+					this.statusBar.updateStatus(RecordingStatus.Paused);
+					new Notice("Recording paused");
+				} else if (state === "paused") {
+					await this.recorder.pauseRecording();
+					this.statusBar.updateStatus(RecordingStatus.Recording);
+					new Notice("Recording resumed");
 				}
 			},
 		});

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -33,7 +33,7 @@ export class Controls extends Modal {
 		// Add record button
 		this.startButton = new ButtonComponent(buttonGroupEl);
 		this.startButton
-			.setIcon("microphone")
+			.setIcon("circle")
 			.setButtonText(" Record")
 			.onClick(this.startRecording.bind(this))
 			.buttonEl.addClass("button-component");
@@ -61,10 +61,11 @@ export class Controls extends Modal {
 			.setButtonText(" Cancel")
 			.onClick(this.cancelRecording.bind(this))
 			.buttonEl.addClass("button-component");
+
+		this.resetGUI();
 	}
 
 	async startRecording() {
-		console.log("start");
 		this.plugin.statusBar.updateStatus(RecordingStatus.Recording);
 		await this.plugin.recorder.startRecording();
 		this.plugin.timer.start();
@@ -73,14 +74,17 @@ export class Controls extends Modal {
 	}
 
 	async pauseRecording() {
-		console.log("pausing recording...");
+		const wasPaused = this.plugin.recorder.getRecordingState() === "paused";
 		await this.plugin.recorder.pauseRecording();
 		this.plugin.timer.pause();
+		this.plugin.statusBar.updateStatus(
+			wasPaused ? RecordingStatus.Recording : RecordingStatus.Paused
+		);
+		new Notice(wasPaused ? "Recording resumed" : "Recording paused");
 		this.resetGUI();
 	}
 
 	async stopRecording() {
-		console.log("stopping recording...");
 		this.plugin.statusBar.updateStatus(RecordingStatus.Processing);
 		const blob = await this.plugin.recorder.stopRecording();
 		this.plugin.timer.reset();
@@ -98,10 +102,10 @@ export class Controls extends Modal {
 	}
 
 	async cancelRecording() {
-		console.log("cancelling recording...");
 		await this.plugin.recorder.stopRecording();
 		this.plugin.timer.reset();
 		this.plugin.statusBar.updateStatus(RecordingStatus.Idle);
+		new Notice("Recording cancelled");
 		this.resetGUI();
 		this.close();
 	}
@@ -112,16 +116,32 @@ export class Controls extends Modal {
 
 	resetGUI() {
 		const recorderState = this.plugin.recorder.getRecordingState();
+		const isIdle = recorderState === "inactive" || !recorderState;
+		const isPaused = recorderState === "paused";
 
-		this.startButton.setDisabled(
-			recorderState === "recording" || recorderState === "paused"
-		);
-		this.pauseButton.setDisabled(recorderState === "inactive");
-		this.stopButton.setDisabled(recorderState === "inactive");
-		this.cancelButton.setDisabled(recorderState === "inactive");
+		// Record: only visible when idle
+		this.startButton.buttonEl.style.display = isIdle ? "" : "none";
+		this.startButton.buttonEl.empty();
+		this.startButton.buttonEl.empty();
+		this.startButton.setIcon("circle");
+		this.startButton.buttonEl.appendText(" Record");
 
-		this.pauseButton.setButtonText(
-			recorderState === "paused" ? " Resume" : " Pause"
-		);
+		// Pause/Resume: visible when recording or paused
+		this.pauseButton.buttonEl.style.display = isIdle ? "none" : "";
+		this.pauseButton.buttonEl.empty();
+		this.pauseButton.setIcon(isPaused ? "play" : "pause");
+		this.pauseButton.buttonEl.appendText(isPaused ? " Resume" : " Pause");
+
+		// Stop: visible when recording or paused
+		this.stopButton.buttonEl.style.display = isIdle ? "none" : "";
+		this.stopButton.buttonEl.empty();
+		this.stopButton.setIcon("square");
+		this.stopButton.buttonEl.appendText(" Stop");
+
+		// Cancel: visible when recording or paused
+		this.cancelButton.buttonEl.style.display = isIdle ? "none" : "";
+		this.cancelButton.buttonEl.empty();
+		this.cancelButton.setIcon("x");
+		this.cancelButton.buttonEl.appendText(" Cancel");
 	}
 }

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -3,6 +3,7 @@ import { Plugin } from "obsidian";
 export enum RecordingStatus {
 	Idle = "idle",
 	Recording = "recording",
+	Paused = "paused",
 	Processing = "processing",
 }
 
@@ -29,9 +30,13 @@ export class StatusBar {
 					this.statusBarItem.textContent = "Recording...";
 					this.statusBarItem.style.color = "red";
 					break;
+				case RecordingStatus.Paused:
+					this.statusBarItem.textContent = "Paused";
+					this.statusBarItem.style.color = "yellow";
+					break;
 				case RecordingStatus.Processing:
-					this.statusBarItem.textContent = "Processing audio...";
-					this.statusBarItem.style.color = "orange";
+					this.statusBarItem.textContent = "Processing...";
+					this.statusBarItem.style.color = "gray";
 					break;
 				case RecordingStatus.Idle:
 				default:

--- a/styles.css
+++ b/styles.css
@@ -8,25 +8,31 @@
 .recording-controls .button-group {
 	display: flex;
 	justify-content: center;
-	gap: 10px;
+	gap: 8px;
 }
 .recording-controls .button-component {
-	padding: 5px 10px;
-}
-
-.recording-controls .button-component {
-	background-color: var(--text-accent);
-	color: var(--text-light);
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	padding: 6px 12px;
+	border-radius: 6px;
+	background-color: var(--interactive-accent);
+	color: var(--text-on-accent);
 	cursor: pointer;
+	font-size: var(--font-ui-small);
 }
 
 .recording-controls .button-component:hover {
-	background-color: var(--text-accent-hover);
+	background-color: var(--interactive-accent-hover);
 }
 
 .recording-controls .button-component:disabled {
 	pointer-events: none;
-	background-color: var(--text-accent-muted);
-	color: var(--text-muted);
+	opacity: 0.4;
 	cursor: not-allowed;
+}
+
+.recording-controls .button-component svg {
+	width: 14px;
+	height: 14px;
 }

--- a/tests/StatusBar.test.ts
+++ b/tests/StatusBar.test.ts
@@ -5,6 +5,7 @@ describe("RecordingStatus enum", () => {
 	it("has expected values", () => {
 		expect(RecordingStatus.Idle).toBe("idle");
 		expect(RecordingStatus.Recording).toBe("recording");
+		expect(RecordingStatus.Paused).toBe("paused");
 		expect(RecordingStatus.Processing).toBe("processing");
 	});
 });


### PR DESCRIPTION
## Summary

- Buttons show/hide based on state instead of enable/disable
- Idle: only Record visible
- Recording: Pause / Stop / Cancel
- Paused: Resume (replaces Pause) / Stop / Cancel
- Added "Paused" (yellow) status bar state
- Processing color changed from orange to gray
- Pause/resume command palette feedback with notices

## Test plan

- [x] 64 tests pass
- [ ] Manual: test Record -> Pause -> Resume -> Stop flow
- [ ] Manual: test Alt+Q while paused stops recording