### PR TITLE
feat: note filename and content templates

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -1,7 +1,12 @@
 import axios from "axios";
 import Whisper from "main";
 import { Notice, MarkdownView } from "obsidian";
-import { getBaseFileName, getCursorContext } from "./utils";
+import {
+	getBaseFileName,
+	getCursorContext,
+	buildTemplateVariables,
+	resolveTemplate,
+} from "./utils";
 import { PostProcessor } from "./PostProcessor";
 
 export class AudioHandler {
@@ -160,7 +165,7 @@ export class AudioHandler {
 			}
 
 			// Auto-generate title for the note filename
-			let resolvedNoteFilePath = noteFilePath;
+			let generatedTitle = baseFileName;
 			if (
 				this.plugin.settings.autoGenerateTitle &&
 				this.plugin.settings.createNewFileAfterRecording
@@ -180,19 +185,15 @@ export class AudioHandler {
 							.replace(/[/\\?%*:|"<>\n]/g, "-")
 							.trim();
 						if (sanitizedTitle) {
-							const folder = this.plugin.settings.createNewFileAfterRecordingPath;
-							resolvedNoteFilePath = `${
-								folder ? `${folder}/` : ""
-							}${sanitizedTitle}.md`;
+							generatedTitle = sanitizedTitle;
 						}
 					} catch (err) {
 						console.error("Title generation failed:", err);
-						// Fall back to default filename
 					}
 				}
 			}
 
-			// Build note content
+			// Build note content with templates
 			const outputText = this.plugin.settings.keepOriginalTranscription && finalText !== originalText
 				? `${finalText}\n\n---\n\n*Original transcription:*\n${originalText}`
 				: finalText;
@@ -201,14 +202,36 @@ export class AudioHandler {
 				await this.ensureFolderExists(
 					this.plugin.settings.createNewFileAfterRecordingPath
 				);
-				let noteContent = outputText;
-				if (this.plugin.settings.saveAudioFile) {
-					const audioRef =
-						this.plugin.settings.audioLinkStyle === "link"
-							? `[[${audioFilePath}]]`
-							: `![[${audioFilePath}]]`;
-					noteContent = `${audioRef}\n${outputText}`;
-				}
+
+				const audioRef = this.plugin.settings.saveAudioFile
+					? (this.plugin.settings.audioLinkStyle === "link"
+						? `[[${audioFilePath}]]`
+						: `![[${audioFilePath}]]`)
+					: "";
+
+				const vars = buildTemplateVariables(
+					outputText,
+					generatedTitle,
+					audioRef
+				);
+
+				// Resolve filename template
+				const resolvedFilename = resolveTemplate(
+					this.plugin.settings.noteFilenameTemplate,
+					vars
+				).replace(/[/\\?%*:|"<>\n]/g, "-").trim() || baseFileName;
+
+				const folder = this.plugin.settings.createNewFileAfterRecordingPath;
+				const resolvedNoteFilePath = `${
+					folder ? `${folder}/` : ""
+				}${resolvedFilename}.md`;
+
+				// Resolve note content template
+				const noteContent = resolveTemplate(
+					this.plugin.settings.noteTemplate,
+					vars
+				).trim();
+
 				await this.plugin.app.vault.create(
 					resolvedNoteFilePath,
 					noteContent

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -23,6 +23,8 @@ export interface WhisperSettings {
 	audioLinkStyle: "embed" | "link";
 	pasteAtCursor: boolean;
 	ignoreUploadFilename: boolean;
+	noteFilenameTemplate: string;
+	noteTemplate: string;
 }
 
 export interface PostProcessingSettings {
@@ -61,6 +63,8 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	audioLinkStyle: "embed",
 	pasteAtCursor: false,
 	ignoreUploadFilename: false,
+	noteFilenameTemplate: "{{date}} {{title}}",
+	noteTemplate: "{{audio}}\n{{transcription}}",
 };
 
 export const DEFAULT_POST_PROCESSING: PostProcessingSettings = {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -45,6 +45,8 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		this.createSaveAudioFilePathSetting();
 		this.createNewFileToggleSetting();
 		this.createNewFilePathSetting();
+		this.createNoteFilenameTemplateSetting();
+		this.createNoteTemplateSetting();
 		this.createPasteAtCursorSetting();
 		this.createAudioLinkStyleSetting();
 		this.createIgnoreUploadFilenameSetting();
@@ -378,6 +380,45 @@ export class WhisperSettingsTab extends PluginSettingTab {
 							this.plugin.settings
 						);
 					});
+			});
+	}
+
+	private createNoteFilenameTemplateSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Note filename template")
+			.setDesc(
+				"Template for note filenames. Variables: {{date}}, {{time}}, {{datetime}}, {{title}}"
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("{{date}} {{title}}")
+					.setValue(this.plugin.settings.noteFilenameTemplate)
+					.onChange(async (value) => {
+						this.plugin.settings.noteFilenameTemplate = value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					})
+			);
+	}
+
+	private createNoteTemplateSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Note template")
+			.setDesc(
+				"Template for note content. Variables: {{transcription}}, {{audio}}, {{date}}, {{time}}, {{datetime}}, {{title}}"
+			)
+			.addTextArea((text) => {
+				text.setPlaceholder("{{audio}}\n{{transcription}}")
+					.setValue(this.plugin.settings.noteTemplate)
+					.onChange(async (value) => {
+						this.plugin.settings.noteTemplate = value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
+				text.inputEl.rows = 4;
+				text.inputEl.cols = 50;
 			});
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,40 @@ export function getExtensionFromMimeType(mimeType: string | undefined): string {
 	return extensionMap[subtype] || subtype;
 }
 
+export interface TemplateVariables {
+	date: string;
+	time: string;
+	datetime: string;
+	title: string;
+	transcription: string;
+	audio: string;
+}
+
+export function buildTemplateVariables(
+	transcription: string,
+	title: string,
+	audioRef: string
+): TemplateVariables {
+	const now = new Date();
+	const date = now.toISOString().split("T")[0];
+	const time = now.toTimeString().split(" ")[0].replace(/:/g, "-");
+	const datetime = `${date} ${now.toTimeString().split(" ")[0]}`;
+	return { date, time, datetime, title, transcription, audio: audioRef };
+}
+
+export function resolveTemplate(
+	template: string,
+	vars: TemplateVariables
+): string {
+	return template
+		.replace(/\{\{date\}\}/g, vars.date)
+		.replace(/\{\{time\}\}/g, vars.time)
+		.replace(/\{\{datetime\}\}/g, vars.datetime)
+		.replace(/\{\{title\}\}/g, vars.title)
+		.replace(/\{\{transcription\}\}/g, vars.transcription)
+		.replace(/\{\{audio\}\}/g, vars.audio);
+}
+
 export function getBaseFileName(filePath: string) {
 	// Extract the file name including extension
 	const fileName = filePath.substring(filePath.lastIndexOf("/") + 1);

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { getBaseFileName, getCursorContext, getExtensionFromMimeType } from "../src/utils";
+import {
+	getBaseFileName,
+	getCursorContext,
+	getExtensionFromMimeType,
+	resolveTemplate,
+	buildTemplateVariables,
+} from "../src/utils";
 
 describe("getBaseFileName", () => {
 	it("strips extension from simple filename", () => {
@@ -78,5 +84,64 @@ describe("getExtensionFromMimeType", () => {
 
 	it("maps mpeg to mp3", () => {
 		expect(getExtensionFromMimeType("audio/mpeg")).toBe("mp3");
+	});
+});
+
+describe("resolveTemplate", () => {
+	const vars = {
+		date: "2026-04-05",
+		time: "14-30-00",
+		datetime: "2026-04-05 14:30:00",
+		title: "Meeting Notes",
+		transcription: "Hello world",
+		audio: "![[recordings/rec.webm]]",
+	};
+
+	it("replaces all placeholders", () => {
+		const result = resolveTemplate(
+			"{{audio}}\n# {{title}}\n{{transcription}}",
+			vars
+		);
+		expect(result).toBe(
+			"![[recordings/rec.webm]]\n# Meeting Notes\nHello world"
+		);
+	});
+
+	it("replaces date/time placeholders in filename", () => {
+		const result = resolveTemplate("{{date}} {{title}}", vars);
+		expect(result).toBe("2026-04-05 Meeting Notes");
+	});
+
+	it("handles multiple occurrences of same variable", () => {
+		const result = resolveTemplate("{{date}} - {{date}}", vars);
+		expect(result).toBe("2026-04-05 - 2026-04-05");
+	});
+
+	it("leaves unknown placeholders unchanged", () => {
+		const result = resolveTemplate("{{unknown}} {{date}}", vars);
+		expect(result).toBe("{{unknown}} 2026-04-05");
+	});
+
+	it("handles template with no placeholders", () => {
+		const result = resolveTemplate("plain text", vars);
+		expect(result).toBe("plain text");
+	});
+
+	it("handles empty audio ref gracefully", () => {
+		const noAudioVars = { ...vars, audio: "" };
+		const result = resolveTemplate("{{audio}}\n{{transcription}}", noAudioVars);
+		expect(result).toBe("\nHello world");
+	});
+});
+
+describe("buildTemplateVariables", () => {
+	it("produces variables with correct types", () => {
+		const vars = buildTemplateVariables("text", "title", "![[audio.webm]]");
+		expect(vars.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(vars.time).toMatch(/^\d{2}-\d{2}-\d{2}$/);
+		expect(vars.datetime).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+		expect(vars.title).toBe("title");
+		expect(vars.transcription).toBe("text");
+		expect(vars.audio).toBe("![[audio.webm]]");
 	});
 });


### PR DESCRIPTION
## Summary
- Customizable templates for note filenames and content using placeholders
- Available variables: `{{date}}`, `{{time}}`, `{{datetime}}`, `{{title}}`, `{{transcription}}`, `{{audio}}`
- Default filename: `{{date}} {{title}}`, default content: `{{audio}}\n{{transcription}}`
- Works with auto-generated titles from post-processing

Closes #66

## Test plan
- [ ] Set filename template to `{{datetime}} - {{title}}` — verify note gets named accordingly
- [ ] Set content template to `# {{title}}\n{{audio}}\n{{transcription}}` — verify note has heading
- [ ] Verify empty `{{audio}}` when save recording is off
- [ ] Verify defaults work without changing templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)