### PR TITLE
feat: store API keys in Obsidian SecretStorage

### DIFF
--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -1,5 +1,11 @@
 import { Plugin } from "obsidian";
 
+const SECRET_IDS: Record<keyof ApiKeysSettings, string> = {
+	apiKey: "api-key",
+	openAiApiKey: "openai-api-key",
+	anthropicApiKey: "anthropic-api-key",
+};
+
 export interface ApiKeysSettings {
 	apiKey: string;
 	openAiApiKey: string;
@@ -91,15 +97,52 @@ export class SettingsManager {
 		this.plugin = plugin;
 	}
 
+	private get secrets() {
+		return this.plugin.app.secretStorage;
+	}
+
+	private migrateKeysToSecretStorage(settings: PluginSettings): boolean {
+		let migrated = false;
+		for (const [field, secretId] of Object.entries(SECRET_IDS)) {
+			const key = field as keyof ApiKeysSettings;
+			if (settings[key]) {
+				this.secrets.setSecret(secretId, settings[key]);
+				settings[key] = "";
+				migrated = true;
+			}
+		}
+		return migrated;
+	}
+
+	private loadKeysFromSecretStorage(settings: PluginSettings): void {
+		for (const [field, secretId] of Object.entries(SECRET_IDS)) {
+			const key = field as keyof ApiKeysSettings;
+			settings[key] = this.secrets.getSecret(secretId) ?? "";
+		}
+	}
+
 	async loadSettings(): Promise<PluginSettings> {
-		return Object.assign(
+		const settings = Object.assign(
 			{},
 			DEFAULT_SETTINGS,
 			await this.plugin.loadData()
 		);
+
+		// Migrate any plain-text keys left in data.json
+		if (this.migrateKeysToSecretStorage(settings)) {
+			await this.plugin.saveData(settings);
+		}
+
+		// Populate in-memory settings from SecretStorage
+		this.loadKeysFromSecretStorage(settings);
+		return settings;
 	}
 
 	async saveSettings(settings: PluginSettings): Promise<void> {
+		// Move any new keys to SecretStorage before persisting
+		this.migrateKeysToSecretStorage(settings);
 		await this.plugin.saveData(settings);
+		// Restore keys in memory so the rest of the plugin can use them
+		this.loadKeysFromSecretStorage(settings);
 	}
 }


### PR DESCRIPTION
## Summary
- API keys are now stored in Obsidian's [SecretStorage API](https://docs.obsidian.md/Reference/TypeScript+API/SecretStorage) instead of `data.json`
- Existing plain-text keys are automatically migrated on first load — no user action needed
- Users can safely commit their vault to git without exposing credentials

Inspired by #83 — reimplemented against the current codebase (v1.8.2) which now has three separate API key fields.

## Test plan
- [ ] Fresh install: add an API key in settings, verify it works for transcription, verify `data.json` does not contain the key
- [ ] Existing install: open plugin with keys already in `data.json`, verify they are migrated (keys cleared from `data.json`, transcription still works)
- [ ] All three key fields (Whisper, OpenAI, Anthropic) are migrated and resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)