### PR TITLE
feat: auto-split long audio into silence-aware segments for transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ obsidian://whisper?command=cancel           discard recording
 
 ## Manual Installation
 
-Download `manifest.json`, `main.js`, `styles.css` from [releases](https://github.com/SecurityBoblin/whisper-obsidian-plugin/releases) into `.obsidian/plugins/whisper-system-audio/` in your vault.
+Download `manifest.json`, `main.js`, `styles.css` from [releases](https://github.com/SecurityBoblin/whisper-obsidian-plugin-meeting-fork/releases) into `.obsidian/plugins/whisper-system-audio/` in your vault.
 
 ## Note Templates
 

--- a/README.md
+++ b/README.md
@@ -1,55 +1,124 @@
-# Whisper — Speech-to-text for Obsidian
+# Whisper + System Audio — Speech-to-text for Obsidian
 
-Record or upload audio, transcribe with [Whisper](https://openai.com/research/whisper), and optionally post-process the result with an LLM. Works on desktop and mobile.
+> **Fork of [nikdanilov/whisper-obsidian-plugin](https://github.com/nikdanilov/whisper-obsidian-plugin)**
 
-Works with OpenAI, Groq, Azure, or any other Whisper-compatible API.
+Record or upload audio, transcribe with [Whisper](https://openai.com/research/whisper), and optionally post-process the result with an LLM.
+
+**This fork adds system audio capture** — transcribe online meetings, videos, music, and any app audio playing on your computer.
+
+## Why This Fork?
+
+The original plugin only supports microphone input. This fork adds native system audio capture using Electron's `desktopCapturer` API, enabling transcription of:
+
+- Online meetings (Zoom, Teams, Meet, etc.)
+- Videos and presentations
+- Music and podcasts
+- Any app audio
+
+Since this feature requires Electron APIs and changes the core recording flow, I created a fork rather than submitting a PR that would significantly alter the original plugin's scope.
+
+**Changes from upstream:**
+- Added system audio capture via `@electron/remote.desktopCapturer`
+- Three recording modes via separate hotkeys (no settings toggle needed)
+- Desktop-only (mobile not supported)
+- Added "Paste at cursor" toggle setting
+- Source selector modal with window/screen thumbnails
 
 ## Quick Start
 
-1. Install from **Settings → Community Plugins** → search "Whisper"
+1. Install from **Settings → Community Plugins** → search "Whisper + System Audio" (or install manually)
 2. Add your API key in the plugin settings
-3. Open a note, press `Alt + Q`, speak, press `Alt + Q` again
+3. Choose your recording mode:
+   - **Alt+Q** — Record Microphone + System Audio (for meetings)
+   - **Alt+Shift+Q** — Record Microphone only
+   - **Alt+Ctrl+Q** — Record System Audio only (for videos/music)
+4. Press the hotkey again to stop and transcribe
 
-The transcription appears at your cursor.
+The transcription appears in a new note file.
+
+## Recording Modes
+
+| Hotkey | Mode | Use Case |
+|--------|------|----------|
+| `Alt+Q` | Microphone + System Audio | Online meetings where you speak and want to capture others |
+| `Alt+Shift+Q` | Microphone only | Voice notes, dictation |
+| `Alt+Ctrl+Q` | System Audio only | Transcribing videos, music, or meetings where you don't speak |
+
+Customize these in **Settings → Hotkeys**.
+
+## System Audio Capture
+
+When using system audio modes, you'll see a window picker showing all available windows and screens. Select the one playing audio you want to capture.
+
+**Tips:**
+- Select a specific window (browser tab, media player) rather than "Entire Screen" for best results
+- Make sure audio is playing when you start recording
+- On macOS, you may need to grant screen recording permissions
+
+**Platform Support:**
+| Platform | Support |
+|----------|---------|
+| Windows | Full support |
+| macOS 13+ | Supported |
+| macOS < 13 | Requires virtual audio device (BlackHole) |
+| Linux | Supported via PipeWire |
+| Mobile | Not supported (desktop-only plugin) |
+
+## All Features
+
+### Recording
+- Three recording modes with dedicated hotkeys
+- Pause/resume recordings
+- Cancel and discard
+- Microphone device selection
+- System audio source picker with thumbnails
+
+### Transcription
+- Works with OpenAI, Groq, Azure, or any Whisper-compatible API
+- Language auto-detection or manual selection
+- Custom prompts for better accuracy with specific terms
+- Temperature and response format settings
+
+### Post-Processing
+- Clean up transcriptions with Claude, GPT, or custom endpoints
+- Auto-generate descriptive filenames
+- Keep original transcription alongside processed version
+
+### Output
+- Save audio files to vault
+- Create note files with templates
+- Optional paste at cursor position
+- Template variables: `{{date}}`, `{{time}}`, `{{datetime}}`, `{{title}}`, `{{transcription}}`, `{{audioFile}}`
 
 ## Usage
 
-**Record** — click the mic icon in the sidebar, or press `Alt + Q` to start/stop.
+**Record** — Use hotkeys or command palette.
 
-**Upload** — command palette → *Upload audio file* (mp3, mp4, m4a, wav, webm, ogg).
+**Upload** — Command palette → *Upload audio file* (mp3, mp4, m4a, wav, webm, ogg).
 
-**Right-click** — right-click any audio file in your vault → *Transcribe audio file*.
-
-All commands can be assigned custom hotkeys in Obsidian's hotkey settings:
-
-- Start/stop recording (`Alt + Q` by default)
-- Pause/resume recording
-- Open recording controls
-- Upload audio file
+**Right-click** — Right-click any audio file → *Transcribe audio file*.
 
 ### Automation
 
 Trigger from iOS Shortcuts, Alfred, or any tool that can open URLs:
 
 ```
-obsidian://whisper                 open controls
-obsidian://whisper?command=start   start recording
-obsidian://whisper?command=stop    stop and transcribe
-obsidian://whisper?command=pause   pause/resume
-obsidian://whisper?command=cancel  discard recording
+obsidian://whisper                          open controls
+obsidian://whisper?command=start            start recording (both)
+obsidian://whisper?command=start&mode=mic   start microphone only
+obsidian://whisper?command=start&mode=system start system audio only
+obsidian://whisper?command=stop             stop and transcribe
+obsidian://whisper?command=pause            pause/resume
+obsidian://whisper?command=cancel           discard recording
 ```
 
-## Post-Processing
+## Manual Installation
 
-Enable **Post-processing** in settings to run transcriptions through an LLM — fix grammar, remove filler words, format as markdown, extract action items.
-
-Supports Claude, GPT, or any OpenAI-compatible endpoint (Ollama, LM Studio, etc.).
-
-You can also enable **Auto-generate title** to create descriptive filenames for your notes.
+Download `manifest.json`, `main.js`, `styles.css` from [releases](https://github.com/SecurityBoblin/whisper-obsidian-plugin/releases) into `.obsidian/plugins/whisper-system-audio/` in your vault.
 
 ## Note Templates
 
-When **Create note file** is enabled, you can customize the filename and content using template variables:
+When **Create note file** is enabled:
 
 | Variable | Example |
 |---|---|
@@ -60,8 +129,7 @@ When **Create note file** is enabled, you can customize the filename and content
 | `{{time}}` | `14-30-00` |
 | `{{datetime}}` | `2026-04-05 14:30:00` |
 
-Example note template:
-
+Example template:
 ```
 # {{title}}
 ![[{{audioFile}}]]
@@ -69,18 +137,12 @@ Example note template:
 {{transcription}}
 ```
 
-Use `![[{{audioFile}}]]` to embed audio (playable) or `[[{{audioFile}}]]` to link.
+## Credits
 
-## Manual Installation
+This is a fork of [nikdanilov/whisper-obsidian-plugin](https://github.com/nikdanilov/whisper-obsidian-plugin) by [Nik Danilov](https://nikdanilov.com).
 
-Download `manifest.json`, `main.js`, `styles.css` from [releases](https://github.com/nikdanilov/whisper-obsidian-plugin/releases) into `.obsidian/plugins/whisper/` in your vault.
-
-## Contributing
-
-Issues and PRs welcome — [GitHub Issues](https://github.com/nikdanilov/whisper-obsidian-plugin/issues)
+The original plugin is excellent for voice transcription. This fork adds system audio capture for a specific use case (transcribing meetings).
 
 ---
 
-[Buy me a coffee](https://ko-fi.com/nikdanilov) · [@nikdanilov\_](https://twitter.com/nikdanilov_)
-
-[<img src="https://user-images.githubusercontent.com/14358394/115450238-f39e8100-a21b-11eb-89d0-fa4b82cdbce8.png" width="200">](https://ko-fi.com/nikdanilov)
+[Support the original author](https://ko-fi.com/nikdanilov) · [Original repo](https://github.com/nikdanilov/whisper-obsidian-plugin)

--- a/main.ts
+++ b/main.ts
@@ -34,6 +34,7 @@ export default class Whisper extends Plugin {
 				? null
 				: this.settings.audioDeviceId;
 		this.recorder.setDeviceId(deviceId);
+		this.recorder.setAudioSourceMode(this.settings.audioSourceMode);
 
 		this.statusBar = new StatusBar(this);
 
@@ -110,10 +111,8 @@ export default class Whisper extends Plugin {
 		try {
 			await this.recorder.startRecording();
 			this.statusBar.updateStatus(RecordingStatus.Recording);
-			new Notice("Recording...");
 		} catch (err) {
 			this.statusBar.updateStatus(RecordingStatus.Idle);
-			new Notice("✘ Could not start recording");
 		}
 	}
 

--- a/main.ts
+++ b/main.ts
@@ -29,6 +29,7 @@ export default class Whisper extends Plugin {
 		this.timer = new Timer();
 		this.audioHandler = new AudioHandler(this);
 		this.recorder = new NativeAudioRecorder();
+		this.recorder.setApp(this.app);
 		const deviceId =
 			this.settings.audioDeviceId === "default"
 				? null

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { Timer } from "src/Timer";
 import { Controls } from "src/Controls";
 import { AudioHandler } from "src/AudioHandler";
 import { WhisperSettingsTab } from "src/WhisperSettingsTab";
-import { SettingsManager, PluginSettings } from "src/SettingsManager";
+import { SettingsManager, PluginSettings, AudioSourceMode } from "src/SettingsManager";
 import { NativeAudioRecorder } from "src/AudioRecorder";
 import { RecordingStatus, StatusBar } from "src/StatusBar";
 import { getExtensionFromMimeType } from "src/utils";
@@ -35,7 +35,6 @@ export default class Whisper extends Plugin {
 				? null
 				: this.settings.audioDeviceId;
 		this.recorder.setDeviceId(deviceId);
-		this.recorder.setAudioSourceMode(this.settings.audioSourceMode);
 
 		this.statusBar = new StatusBar(this);
 
@@ -76,7 +75,7 @@ export default class Whisper extends Plugin {
 					return;
 
 				menu.addItem((item) => {
-					item.setTitle("Transcribe audio file 🔊")
+					item.setTitle("Transcribe audio file")
 						.setIcon("document")
 						.onClick(async () => {
 							const audioBlob = new Blob([
@@ -101,7 +100,7 @@ export default class Whisper extends Plugin {
 
 	// --- Recording state transitions (single source of truth) ---
 
-	async startRecording() {
+	async startRecording(mode: AudioSourceMode = "both") {
 		if (
 			this.statusBar.status === RecordingStatus.Recording ||
 			this.statusBar.status === RecordingStatus.Paused
@@ -110,7 +109,7 @@ export default class Whisper extends Plugin {
 			return;
 		}
 		try {
-			await this.recorder.startRecording();
+			await this.recorder.startRecording(mode);
 			this.statusBar.updateStatus(RecordingStatus.Recording);
 		} catch (err) {
 			this.statusBar.updateStatus(RecordingStatus.Idle);
@@ -126,7 +125,8 @@ export default class Whisper extends Plugin {
 		}
 		this.statusBar.updateStatus(RecordingStatus.Processing);
 		const audioBlob = await this.recorder.stopRecording();
-		const extension = getExtensionFromMimeType(this.recorder.getMimeType());
+		const mimeType = this.recorder.getMimeType();
+		const extension = getExtensionFromMimeType(mimeType);
 		const fileName = `${new Date()
 			.toISOString()
 			.replace(/[:.]/g, "-")}.${extension}`;
@@ -168,20 +168,55 @@ export default class Whisper extends Plugin {
 	// --- Commands ---
 
 	addCommands() {
+		// Record: Microphone + System Audio (default)
 		this.addCommand({
-			id: "start-stop-recording",
-			name: "Start/stop recording",
+			id: "record-both",
+			name: "Record: Microphone + System Audio",
 			callback: async () => {
 				if (
 					this.statusBar.status !== RecordingStatus.Recording &&
 					this.statusBar.status !== RecordingStatus.Paused
 				) {
-					await this.startRecording();
+					await this.startRecording("both");
 				} else {
 					await this.stopRecording();
 				}
 			},
 			hotkeys: [{ modifiers: ["Alt"], key: "Q" }],
+		});
+
+		// Record: Microphone only
+		this.addCommand({
+			id: "record-microphone",
+			name: "Record: Microphone",
+			callback: async () => {
+				if (
+					this.statusBar.status !== RecordingStatus.Recording &&
+					this.statusBar.status !== RecordingStatus.Paused
+				) {
+					await this.startRecording("microphone");
+				} else {
+					await this.stopRecording();
+				}
+			},
+			hotkeys: [{ modifiers: ["Alt", "Shift"], key: "Q" }],
+		});
+
+		// Record: System Audio only
+		this.addCommand({
+			id: "record-system",
+			name: "Record: System Audio",
+			callback: async () => {
+				if (
+					this.statusBar.status !== RecordingStatus.Recording &&
+					this.statusBar.status !== RecordingStatus.Paused
+				) {
+					await this.startRecording("system");
+				} else {
+					await this.stopRecording();
+				}
+			},
+			hotkeys: [{ modifiers: ["Alt", "Ctrl"], key: "Q" }],
 		});
 
 		this.addCommand({
@@ -232,7 +267,8 @@ export default class Whisper extends Plugin {
 
 			switch (command) {
 				case "start":
-					await this.startRecording();
+					const mode = (params.mode as AudioSourceMode) || "both";
+					await this.startRecording(mode);
 					break;
 				case "stop":
 					await this.stopRecording();
@@ -244,7 +280,7 @@ export default class Whisper extends Plugin {
 					await this.cancelRecording();
 					break;
 				default:
-					new Notice(`✘ Unknown whisper command: ${command}`);
+					new Notice(`Unknown whisper command: ${command}`);
 			}
 		});
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-  "id": "whisper",
-  "name": "Whisper",
-  "version": "1.9.1",
+  "id": "whisper-system-audio",
+  "name": "Whisper + System Audio",
+  "version": "1.0.0",
   "minAppVersion": "1.12.7",
-  "description": "Speech-to-text in Obsidian using OpenAI Whisper",
-  "author": "Nik Danilov",
-  "authorUrl": "https://nikdanilov.com",
-  "fundingUrl": "https://ko-fi.com/nikdanilov",
+  "description": "Speech-to-text in Obsidian using OpenAI Whisper, with system audio capture for transcribing meetings",
+  "author": "SecurityBoblin (forked from Nik Danilov)",
+  "authorUrl": "https://github.com/SecurityBoblin/whisper-obsidian-plugin",
+  "fundingUrl": "https://github.com/nikdanilov/whisper-obsidian-plugin",
   "isDesktopOnly": true
 }

--- a/manifest.json
+++ b/manifest.json
@@ -7,5 +7,5 @@
   "author": "Nik Danilov",
   "authorUrl": "https://nikdanilov.com",
   "fundingUrl": "https://ko-fi.com/nikdanilov",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -110,7 +110,8 @@ export class AudioHandler {
 		const segments = await splitAudioBlob(
 			blob,
 			SEGMENT_DURATION_SECONDS,
-			preDecoded
+			preDecoded,
+			this.plugin.settings.silenceThreshold
 		);
 		const texts: string[] = new Array(segments.length);
 		const concurrency = this.plugin.settings.concurrentTranscriptions;

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -8,6 +8,12 @@ import {
 	resolveTemplate,
 } from "./utils";
 import { PostProcessor } from "./PostProcessor";
+import {
+	getAudioDuration,
+	splitAudioBlob,
+	SPLIT_THRESHOLD_SECONDS,
+	SEGMENT_DURATION_SECONDS,
+} from "./AudioSplitter";
 
 export class AudioHandler {
 	private plugin: Whisper;
@@ -36,38 +42,12 @@ export class AudioHandler {
 		}
 	}
 
-	async sendAudioData(blob: Blob, fileName: string): Promise<void> {
-		// Get the base file name without extension
-		const baseFileName = getBaseFileName(fileName);
-
-		const audioFilePath = `${
-			this.plugin.settings.audioSavePath
-				? `${this.plugin.settings.audioSavePath}/`
-				: ""
-		}${fileName}`;
-
-		const noteFilePath = `${
-			this.plugin.settings.noteSavePath
-				? `${this.plugin.settings.noteSavePath}/`
-				: ""
-		}${baseFileName}.md`;
-
+	private async callTranscriptionApi(
+		blob: Blob,
+		fileName: string
+	): Promise<string> {
 		if (this.plugin.settings.debugMode) {
-			new Notice(`Sending ${Math.round(blob.size / 1000)} KB...`);
-		}
-
-		const isDefaultApi =
-			this.plugin.settings.apiUrl ===
-			"https://api.openai.com/v1/audio/transcriptions";
-		if (isDefaultApi && !this.plugin.settings.apiKey) {
-			new Notice("✘ Add your API key in Whisper settings");
-			return;
-		}
-
-		const MIN_AUDIO_SIZE_BYTES = 1000;
-		if (blob.size < MIN_AUDIO_SIZE_BYTES) {
-			new Notice("✘ Recording too short");
-			return;
+			new Notice("Transcribing...");
 		}
 
 		const formData = new FormData();
@@ -104,6 +84,85 @@ export class AudioHandler {
 				this.plugin.settings.responseFormat
 			);
 
+		const response = await axios.post(
+			this.plugin.settings.apiUrl,
+			formData,
+			{
+				headers: {
+					"Content-Type": "multipart/form-data",
+					...(this.plugin.settings.apiKey
+						? {
+								Authorization: `Bearer ${this.plugin.settings.apiKey}`,
+						  }
+						: {}),
+				},
+			}
+		);
+		return response.data.text as string;
+	}
+
+	private async transcribeSegmented(
+		blob: Blob,
+		baseFileName: string
+	): Promise<string> {
+		const notice = new Notice("Splitting audio...", 0);
+		const segments = await splitAudioBlob(blob, SEGMENT_DURATION_SECONDS);
+		const texts: string[] = [];
+
+		for (let i = 0; i < segments.length; i++) {
+			notice.setMessage(
+				`Transcribing segment ${i + 1}/${segments.length}...`
+			);
+			try {
+				const text = await this.callTranscriptionApi(
+					segments[i],
+					`${baseFileName}_part${i + 1}.wav`
+				);
+				texts.push(text);
+			} catch (err) {
+				console.error(`Segment ${i + 1} transcription failed:`, err);
+				texts.push(`[Segment ${i + 1} transcription failed]`);
+			}
+		}
+
+		notice.hide();
+		return texts.join("\n\n");
+	}
+
+	async sendAudioData(blob: Blob, fileName: string): Promise<void> {
+		// Get the base file name without extension
+		const baseFileName = getBaseFileName(fileName);
+
+		const audioFilePath = `${
+			this.plugin.settings.audioSavePath
+				? `${this.plugin.settings.audioSavePath}/`
+				: ""
+		}${fileName}`;
+
+		const noteFilePath = `${
+			this.plugin.settings.noteSavePath
+				? `${this.plugin.settings.noteSavePath}/`
+				: ""
+		}${baseFileName}.md`;
+
+		if (this.plugin.settings.debugMode) {
+			new Notice(`Sending ${Math.round(blob.size / 1000)} KB...`);
+		}
+
+		const isDefaultApi =
+			this.plugin.settings.apiUrl ===
+			"https://api.openai.com/v1/audio/transcriptions";
+		if (isDefaultApi && !this.plugin.settings.apiKey) {
+			new Notice("✘ Add your API key in Whisper settings");
+			return;
+		}
+
+		const MIN_AUDIO_SIZE_BYTES = 1000;
+		if (blob.size < MIN_AUDIO_SIZE_BYTES) {
+			new Notice("✘ Recording too short");
+			return;
+		}
+
 		try {
 			// If the saveAudioFile setting is true, save the audio file
 			if (this.plugin.settings.saveAudioFile) {
@@ -126,25 +185,13 @@ export class AudioHandler {
 		}
 
 		try {
-			if (this.plugin.settings.debugMode) {
-				new Notice("Transcribing...");
+			const duration = await getAudioDuration(blob);
+			let originalText: string;
+			if (isFinite(duration) && duration > SPLIT_THRESHOLD_SECONDS) {
+				originalText = await this.transcribeSegmented(blob, baseFileName);
+			} else {
+				originalText = await this.callTranscriptionApi(blob, fileName);
 			}
-			const response = await axios.post(
-				this.plugin.settings.apiUrl,
-				formData,
-				{
-					headers: {
-						"Content-Type": "multipart/form-data",
-						...(this.plugin.settings.apiKey
-							? {
-									Authorization: `Bearer ${this.plugin.settings.apiKey}`,
-							  }
-							: {}),
-					},
-				}
-			);
-
-			const originalText: string = response.data.text;
 			let finalText = originalText;
 
 			// Post-process with LLM if enabled

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -112,23 +112,37 @@ export class AudioHandler {
 			SEGMENT_DURATION_SECONDS,
 			preDecoded
 		);
-		const texts: string[] = [];
+		const texts: string[] = new Array(segments.length);
+		const concurrency = this.plugin.settings.concurrentTranscriptions;
 
-		for (let i = 0; i < segments.length; i++) {
-			notice.setMessage(
-				`Transcribing segment ${i + 1}/${segments.length}...`
-			);
-			try {
-				const text = await this.callTranscriptionApi(
-					segments[i],
-					`${baseFileName}_part${i + 1}.wav`
+		// Worker pool: N workers pull from a shared queue so a free worker
+		// immediately picks up the next segment without waiting for others.
+		const queue: Array<[number, Blob]> = segments.map((seg, i) => [i, seg]);
+
+		const worker = async (): Promise<void> => {
+			while (queue.length > 0) {
+				const item = queue.shift();
+				if (!item) return;
+				const [idx, segment] = item;
+				notice.setMessage(
+					`Transcribing segment ${idx + 1}/${segments.length}...`
 				);
-				texts.push(text);
-			} catch (err) {
-				console.error(`Segment ${i + 1} transcription failed:`, err);
-				texts.push(`[Segment ${i + 1} transcription failed]`);
+				try {
+					texts[idx] = await this.callTranscriptionApi(
+						segment,
+						`${baseFileName}_part${idx + 1}.wav`
+					);
+				} catch (err) {
+					console.error(
+						`Segment ${idx + 1} transcription failed:`,
+						err
+					);
+					texts[idx] = `[Segment ${idx + 1} transcription failed]`;
+				}
 			}
-		}
+		};
+
+		await Promise.all(Array.from({ length: concurrency }, worker));
 
 		notice.hide();
 		return texts.join("\n\n");

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -9,7 +9,7 @@ import {
 } from "./utils";
 import { PostProcessor } from "./PostProcessor";
 import {
-	getAudioDuration,
+	probeAudio,
 	splitAudioBlob,
 	SPLIT_THRESHOLD_SECONDS,
 	SEGMENT_DURATION_SECONDS,
@@ -103,10 +103,15 @@ export class AudioHandler {
 
 	private async transcribeSegmented(
 		blob: Blob,
-		baseFileName: string
+		baseFileName: string,
+		preDecoded?: AudioBuffer
 	): Promise<string> {
 		const notice = new Notice("Splitting audio...", 0);
-		const segments = await splitAudioBlob(blob, SEGMENT_DURATION_SECONDS);
+		const segments = await splitAudioBlob(
+			blob,
+			SEGMENT_DURATION_SECONDS,
+			preDecoded
+		);
 		const texts: string[] = [];
 
 		for (let i = 0; i < segments.length; i++) {
@@ -185,10 +190,14 @@ export class AudioHandler {
 		}
 
 		try {
-			const duration = await getAudioDuration(blob);
+			const { duration, buffer: cachedBuffer } = await probeAudio(blob);
 			let originalText: string;
-			if (isFinite(duration) && duration > SPLIT_THRESHOLD_SECONDS) {
-				originalText = await this.transcribeSegmented(blob, baseFileName);
+			if (duration > SPLIT_THRESHOLD_SECONDS) {
+				originalText = await this.transcribeSegmented(
+					blob,
+					baseFileName,
+					cachedBuffer ?? undefined
+				);
 			} else {
 				originalText = await this.callTranscriptionApi(blob, fileName);
 			}

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -254,20 +254,22 @@ export class AudioHandler {
 				);
 			}
 
-			// Paste at cursor if there's an active editor
-			const editor =
-				this.plugin.app.workspace.getActiveViewOfType(
-					MarkdownView
-				)?.editor;
-			if (editor) {
-				const cursorPosition = editor.getCursor();
-				editor.replaceRange(outputText, cursorPosition);
+			// Paste at cursor if setting is enabled
+			if (this.plugin.settings.pasteAtCursor) {
+				const editor =
+					this.plugin.app.workspace.getActiveViewOfType(
+						MarkdownView
+					)?.editor;
+				if (editor) {
+					const cursorPosition = editor.getCursor();
+					editor.replaceRange(outputText, cursorPosition);
 
-				const newPosition = {
-					line: cursorPosition.line,
-					ch: cursorPosition.ch + outputText.length,
-				};
-				editor.setCursor(newPosition);
+					const newPosition = {
+						line: cursorPosition.line,
+						ch: cursorPosition.ch + outputText.length,
+					};
+					editor.setCursor(newPosition);
+				}
 			}
 
 			new Notice("Transcription complete");

--- a/src/AudioRecorder.ts
+++ b/src/AudioRecorder.ts
@@ -1,5 +1,6 @@
-import { Notice } from "obsidian";
+import { App, Notice } from "obsidian";
 import { AudioSourceMode } from "./SettingsManager";
+import { SourceSelectorModal, DesktopSource } from "./SourceSelectorModal";
 
 export interface AudioRecorder {
 	startRecording(): Promise<void>;
@@ -42,6 +43,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 	private audioSourceMode: AudioSourceMode = "microphone";
 	private audioContext: AudioContext | null = null;
 	private activeStreams: MediaStream[] = [];
+	private app: App | null = null;
 
 	getRecordingState(): "inactive" | "recording" | "paused" | undefined {
 		return this.recorder?.state;
@@ -63,6 +65,10 @@ export class NativeAudioRecorder implements AudioRecorder {
 		return this.audioSourceMode;
 	}
 
+	setApp(app: App): void {
+		this.app = app;
+	}
+
 	private async startMicrophoneCapture(): Promise<AudioCaptureResult> {
 		const audioConstraints =
 			this.deviceId && this.deviceId !== "default"
@@ -76,20 +82,110 @@ export class NativeAudioRecorder implements AudioRecorder {
 		return { stream, videoTracks: [] };
 	}
 
+	private isElectron(): boolean {
+		return typeof process !== "undefined" && process.versions && !!process.versions.electron;
+	}
+
+	private async getDesktopCapturer(): Promise<{
+		getSources: (options: { types: string[]; thumbnailSize?: { width: number; height: number } }) => Promise<DesktopSource[]>;
+	} | null> {
+		if (!this.isElectron()) {
+			return null;
+		}
+
+		try {
+			const { desktopCapturer } = require("electron");
+			return desktopCapturer;
+		} catch (e) {
+			console.error("Failed to load desktopCapturer:", e);
+			return null;
+		}
+	}
+
 	private async startSystemAudioCapture(): Promise<AudioCaptureResult> {
-		new Notice("Select a tab, window, or screen to capture audio from");
-		
-		const stream = await navigator.mediaDevices.getDisplayMedia({
-			video: true,
-			audio: true,
-		});
+		const desktopCapturer = await this.getDesktopCapturer();
+
+		if (!desktopCapturer) {
+			throw new Error(
+				"System audio capture requires the desktop version of Obsidian. " +
+				"On mobile, only microphone recording is available."
+			);
+		}
+
+		new Notice("Loading available sources...");
+
+		let sources: DesktopSource[];
+		try {
+			const electronSources = await desktopCapturer.getSources({
+				types: ["window", "screen"],
+				thumbnailSize: { width: 400, height: 250 },
+			});
+			sources = electronSources;
+		} catch (e) {
+			throw new Error(
+				"Failed to enumerate capture sources. Make sure Obsidian has screen recording permissions."
+			);
+		}
+
+		if (sources.length === 0) {
+			throw new Error(
+				"No windows or screens found to capture. Open an application window and try again."
+			);
+		}
+
+		if (!this.app) {
+			throw new Error("App instance not set. Call setApp() before recording.");
+		}
+
+		const selectedSource = await SourceSelectorModal.selectSource(this.app, sources);
+
+		if (!selectedSource) {
+			throw new Error("Source selection cancelled");
+		}
+
+		new Notice(`Capturing from: ${selectedSource.name.substring(0, 30)}...`);
+
+		const constraints: MediaStreamConstraints = {
+			audio: {
+				mandatory: {
+					chromeMediaSource: "desktop",
+					chromeMediaSourceId: selectedSource.id,
+				},
+			} as any,
+			video: {
+				mandatory: {
+					chromeMediaSource: "desktop",
+					chromeMediaSourceId: selectedSource.id,
+				},
+			} as any,
+		};
+
+		let stream: MediaStream;
+		try {
+			stream = await navigator.mediaDevices.getUserMedia(constraints);
+		} catch (e) {
+			const errMsg = e instanceof Error ? e.message : String(e);
+			if (errMsg.includes("Permission")) {
+				throw new Error(
+					"Permission denied. Grant Obsidian screen recording access in System Settings > Privacy & Security > Screen Recording."
+				);
+			}
+			throw new Error(`Failed to capture from selected source: ${errMsg}`);
+		}
 
 		const audioTracks = stream.getAudioTracks();
 		const videoTracks = stream.getVideoTracks();
 
 		if (audioTracks.length === 0) {
 			videoTracks.forEach((track) => track.stop());
-			throw new Error("No audio track available in the selected source. Please select a source with audio (e.g., a browser tab with audio playing).");
+			stream.getTracks().forEach((track) => track.stop());
+			throw new Error(
+				"No audio in selected source.\n\n" +
+				"Tips:\n" +
+				"• Select a window playing audio (browser tab, media player)\n" +
+				"• On Windows: Make sure 'Share audio' was enabled\n" +
+				"• Some apps don't output audio through the capture API"
+			);
 		}
 
 		const audioOnlyStream = new MediaStream(audioTracks);
@@ -143,10 +239,10 @@ export class NativeAudioRecorder implements AudioRecorder {
 				case "both":
 					const micCapture = await this.startMicrophoneCapture();
 					const sysCapture = await this.startSystemAudioCapture();
-					
+
 					this.activeStreams.push(micCapture.stream, sysCapture.stream);
 					videoTracksToStop = [...micCapture.videoTracks, ...sysCapture.videoTracks];
-					
+
 					audioStream = this.mixAudioStreams(
 						micCapture.stream,
 						sysCapture.stream
@@ -184,18 +280,14 @@ export class NativeAudioRecorder implements AudioRecorder {
 
 		} catch (err) {
 			this.cleanupStreams();
-			
+
 			if (err instanceof Error) {
 				if (err.name === "NotAllowedError") {
-					if (this.audioSourceMode === "system" || this.audioSourceMode === "both") {
-						new Notice("Permission denied. Please allow screen/audio sharing to capture system audio.");
-					} else {
-						new Notice("Microphone permission denied");
-					}
-				} else if (err.message.includes("No audio track")) {
-					new Notice(err.message);
+					new Notice("Microphone permission denied");
+				} else if (err.message.includes("cancelled")) {
+					new Notice("Recording cancelled");
 				} else {
-					new Notice(`Could not start recording: ${err.message}`);
+					new Notice(err.message);
 				}
 			} else {
 				new Notice("Could not start recording");

--- a/src/AudioRecorder.ts
+++ b/src/AudioRecorder.ts
@@ -3,7 +3,7 @@ import { AudioSourceMode } from "./SettingsManager";
 import { SourceSelectorModal, DesktopSource } from "./SourceSelectorModal";
 
 export interface AudioRecorder {
-	startRecording(): Promise<void>;
+	startRecording(mode: AudioSourceMode): Promise<void>;
 	pauseRecording(): Promise<void>;
 	stopRecording(): Promise<Blob>;
 }
@@ -40,7 +40,6 @@ export class NativeAudioRecorder implements AudioRecorder {
 	private recorder: MediaRecorder | null = null;
 	private mimeType: string | undefined;
 	private deviceId: string | null = null;
-	private audioSourceMode: AudioSourceMode = "microphone";
 	private audioContext: AudioContext | null = null;
 	private activeStreams: MediaStream[] = [];
 	private app: App | null = null;
@@ -55,14 +54,6 @@ export class NativeAudioRecorder implements AudioRecorder {
 
 	setDeviceId(deviceId: string | null): void {
 		this.deviceId = deviceId;
-	}
-
-	setAudioSourceMode(mode: AudioSourceMode): void {
-		this.audioSourceMode = mode;
-	}
-
-	getAudioSourceMode(): AudioSourceMode {
-		return this.audioSourceMode;
 	}
 
 	setApp(app: App): void {
@@ -83,21 +74,42 @@ export class NativeAudioRecorder implements AudioRecorder {
 	}
 
 	private isElectron(): boolean {
-		return typeof process !== "undefined" && process.versions && !!process.versions.electron;
+		try {
+			const electronRequire = (window as any).require || require;
+			electronRequire("electron");
+			return true;
+		} catch {
+			return false;
+		}
 	}
 
 	private async getDesktopCapturer(): Promise<{
 		getSources: (options: { types: string[]; thumbnailSize?: { width: number; height: number } }) => Promise<DesktopSource[]>;
 	} | null> {
-		if (!this.isElectron()) {
-			return null;
-		}
-
 		try {
-			const { desktopCapturer } = require("electron");
-			return desktopCapturer;
-		} catch (e) {
-			console.error("Failed to load desktopCapturer:", e);
+			const winRequire = (window as any).require;
+			
+			if (typeof winRequire !== "function") {
+				return null;
+			}
+			
+			const electron = winRequire("electron");
+			
+			if (electron && electron.desktopCapturer) {
+				return electron.desktopCapturer;
+			}
+			
+			try {
+				const remote = winRequire("@electron/remote");
+				if (remote && remote.desktopCapturer) {
+					return remote.desktopCapturer;
+				}
+			} catch {
+				// @electron/remote not available
+			}
+			
+			return null;
+		} catch {
 			return null;
 		}
 	}
@@ -107,8 +119,9 @@ export class NativeAudioRecorder implements AudioRecorder {
 
 		if (!desktopCapturer) {
 			throw new Error(
-				"System audio capture requires the desktop version of Obsidian. " +
-				"On mobile, only microphone recording is available."
+				"System audio capture is not available.\n\n" +
+				"This feature requires Obsidian desktop app.\n" +
+				"If you're on desktop, try restarting Obsidian."
 			);
 		}
 
@@ -118,7 +131,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 		try {
 			const electronSources = await desktopCapturer.getSources({
 				types: ["window", "screen"],
-				thumbnailSize: { width: 400, height: 250 },
+				thumbnailSize: { width: 160, height: 100 },
 			});
 			sources = electronSources;
 		} catch (e) {
@@ -214,7 +227,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 		return destination.stream;
 	}
 
-	async startRecording(): Promise<void> {
+	async startRecording(mode: AudioSourceMode): Promise<void> {
 		if (this.recorder) {
 			return;
 		}
@@ -223,7 +236,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 			let audioStream: MediaStream;
 			let videoTracksToStop: MediaStreamTrack[] = [];
 
-			switch (this.audioSourceMode) {
+			switch (mode) {
 				case "microphone":
 					const micResult = await this.startMicrophoneCapture();
 					audioStream = micResult.stream;
@@ -250,7 +263,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 					break;
 
 				default:
-					throw new Error(`Unknown audio source mode: ${this.audioSourceMode}`);
+					throw new Error(`Unknown audio source mode: ${mode}`);
 			}
 
 			this.activeStreams.push(audioStream);
@@ -276,7 +289,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 				system: "system audio",
 				both: "microphone + system audio",
 			};
-			new Notice(`Recording from ${modeName[this.audioSourceMode]}...`);
+			new Notice(`Recording from ${modeName[mode]}...`);
 
 		} catch (err) {
 			this.cleanupStreams();

--- a/src/AudioRecorder.ts
+++ b/src/AudioRecorder.ts
@@ -1,4 +1,5 @@
 import { Notice } from "obsidian";
+import { AudioSourceMode } from "./SettingsManager";
 
 export interface AudioRecorder {
 	startRecording(): Promise<void>;
@@ -28,11 +29,19 @@ function getSupportedMimeType(): string | undefined {
 	return undefined;
 }
 
+interface AudioCaptureResult {
+	stream: MediaStream;
+	videoTracks: MediaStreamTrack[];
+}
+
 export class NativeAudioRecorder implements AudioRecorder {
 	private chunks: BlobPart[] = [];
 	private recorder: MediaRecorder | null = null;
 	private mimeType: string | undefined;
 	private deviceId: string | null = null;
+	private audioSourceMode: AudioSourceMode = "microphone";
+	private audioContext: AudioContext | null = null;
+	private activeStreams: MediaStream[] = [];
 
 	getRecordingState(): "inactive" | "recording" | "paused" | undefined {
 		return this.recorder?.state;
@@ -46,38 +55,166 @@ export class NativeAudioRecorder implements AudioRecorder {
 		this.deviceId = deviceId;
 	}
 
-	async startRecording(): Promise<void> {
-		if (!this.recorder) {
-			try {
-				const audioConstraints =
-					this.deviceId && this.deviceId !== "default"
-						? { deviceId: { exact: this.deviceId } }
-						: true;
-				const stream = await navigator.mediaDevices.getUserMedia({
-					audio: audioConstraints,
-				});
-				this.mimeType = getSupportedMimeType();
+	setAudioSourceMode(mode: AudioSourceMode): void {
+		this.audioSourceMode = mode;
+	}
 
-				if (!this.mimeType) {
-					throw new Error("No supported mimeType found");
-				}
+	getAudioSourceMode(): AudioSourceMode {
+		return this.audioSourceMode;
+	}
 
-				const options = { mimeType: this.mimeType };
-				const recorder = new MediaRecorder(stream, options);
+	private async startMicrophoneCapture(): Promise<AudioCaptureResult> {
+		const audioConstraints =
+			this.deviceId && this.deviceId !== "default"
+				? { deviceId: { exact: this.deviceId } }
+				: true;
 
-				recorder.addEventListener("dataavailable", (e: BlobEvent) => {
-					this.chunks.push(e.data);
-				});
+		const stream = await navigator.mediaDevices.getUserMedia({
+			audio: audioConstraints,
+		});
 
-				this.recorder = recorder;
-			} catch (err) {
-				new Notice("✘ Couldn't access microphone");
-				console.error("Error initializing recorder:", err);
-				return;
-			}
+		return { stream, videoTracks: [] };
+	}
+
+	private async startSystemAudioCapture(): Promise<AudioCaptureResult> {
+		new Notice("Select a tab, window, or screen to capture audio from");
+		
+		const stream = await navigator.mediaDevices.getDisplayMedia({
+			video: true,
+			audio: true,
+		});
+
+		const audioTracks = stream.getAudioTracks();
+		const videoTracks = stream.getVideoTracks();
+
+		if (audioTracks.length === 0) {
+			videoTracks.forEach((track) => track.stop());
+			throw new Error("No audio track available in the selected source. Please select a source with audio (e.g., a browser tab with audio playing).");
 		}
 
-		this.recorder.start(100);
+		const audioOnlyStream = new MediaStream(audioTracks);
+
+		return { stream: audioOnlyStream, videoTracks };
+	}
+
+	private mixAudioStreams(
+		micStream: MediaStream,
+		systemStream: MediaStream
+	): MediaStream {
+		this.audioContext = new AudioContext();
+		const destination = this.audioContext.createMediaStreamDestination();
+
+		const micSource = this.audioContext.createMediaStreamSource(micStream);
+		const systemSource = this.audioContext.createMediaStreamSource(systemStream);
+
+		const micGain = this.audioContext.createGain();
+		const systemGain = this.audioContext.createGain();
+		micGain.gain.value = 1.0;
+		systemGain.gain.value = 1.0;
+
+		micSource.connect(micGain).connect(destination);
+		systemSource.connect(systemGain).connect(destination);
+
+		return destination.stream;
+	}
+
+	async startRecording(): Promise<void> {
+		if (this.recorder) {
+			return;
+		}
+
+		try {
+			let audioStream: MediaStream;
+			let videoTracksToStop: MediaStreamTrack[] = [];
+
+			switch (this.audioSourceMode) {
+				case "microphone":
+					const micResult = await this.startMicrophoneCapture();
+					audioStream = micResult.stream;
+					videoTracksToStop = micResult.videoTracks;
+					break;
+
+				case "system":
+					const sysResult = await this.startSystemAudioCapture();
+					audioStream = sysResult.stream;
+					videoTracksToStop = sysResult.videoTracks;
+					break;
+
+				case "both":
+					const micCapture = await this.startMicrophoneCapture();
+					const sysCapture = await this.startSystemAudioCapture();
+					
+					this.activeStreams.push(micCapture.stream, sysCapture.stream);
+					videoTracksToStop = [...micCapture.videoTracks, ...sysCapture.videoTracks];
+					
+					audioStream = this.mixAudioStreams(
+						micCapture.stream,
+						sysCapture.stream
+					);
+					break;
+
+				default:
+					throw new Error(`Unknown audio source mode: ${this.audioSourceMode}`);
+			}
+
+			this.activeStreams.push(audioStream);
+
+			this.mimeType = getSupportedMimeType();
+
+			if (!this.mimeType) {
+				throw new Error("No supported mimeType found");
+			}
+
+			const options = { mimeType: this.mimeType };
+			const recorder = new MediaRecorder(audioStream, options);
+
+			recorder.addEventListener("dataavailable", (e: BlobEvent) => {
+				this.chunks.push(e.data);
+			});
+
+			this.recorder = recorder;
+			this.recorder.start(100);
+
+			const modeName = {
+				microphone: "microphone",
+				system: "system audio",
+				both: "microphone + system audio",
+			};
+			new Notice(`Recording from ${modeName[this.audioSourceMode]}...`);
+
+		} catch (err) {
+			this.cleanupStreams();
+			
+			if (err instanceof Error) {
+				if (err.name === "NotAllowedError") {
+					if (this.audioSourceMode === "system" || this.audioSourceMode === "both") {
+						new Notice("Permission denied. Please allow screen/audio sharing to capture system audio.");
+					} else {
+						new Notice("Microphone permission denied");
+					}
+				} else if (err.message.includes("No audio track")) {
+					new Notice(err.message);
+				} else {
+					new Notice(`Could not start recording: ${err.message}`);
+				}
+			} else {
+				new Notice("Could not start recording");
+			}
+			console.error("Error initializing recorder:", err);
+			throw err;
+		}
+	}
+
+	private cleanupStreams(): void {
+		this.activeStreams.forEach((stream) => {
+			stream.getTracks().forEach((track) => track.stop());
+		});
+		this.activeStreams = [];
+
+		if (this.audioContext) {
+			this.audioContext.close();
+			this.audioContext = null;
+		}
 	}
 
 	async pauseRecording(): Promise<void> {
@@ -97,6 +234,7 @@ export class NativeAudioRecorder implements AudioRecorder {
 			if (!this.recorder || this.recorder.state === "inactive") {
 				const blob = new Blob(this.chunks, { type: this.mimeType });
 				this.chunks.length = 0;
+				this.cleanupStreams();
 				resolve(blob);
 			} else {
 				this.recorder.addEventListener(
@@ -107,13 +245,8 @@ export class NativeAudioRecorder implements AudioRecorder {
 						});
 						this.chunks.length = 0;
 
-						// will stop all the tracks associated with the stream, effectively releasing any resources (like the mic) used by them
-						if (this.recorder) {
-							this.recorder.stream
-								.getTracks()
-								.forEach((track) => track.stop());
-							this.recorder = null;
-						}
+						this.cleanupStreams();
+						this.recorder = null;
 
 						resolve(blob);
 					},

--- a/src/AudioSplitter.ts
+++ b/src/AudioSplitter.ts
@@ -1,0 +1,97 @@
+export const SPLIT_THRESHOLD_SECONDS = 600; // 10 minutes
+export const SEGMENT_DURATION_SECONDS = 300; // 5 minutes
+
+export async function getAudioDuration(blob: Blob): Promise<number> {
+	return new Promise((resolve) => {
+		const audio = document.createElement("audio");
+		const url = URL.createObjectURL(blob);
+		audio.onloadedmetadata = () => {
+			URL.revokeObjectURL(url);
+			resolve(audio.duration);
+		};
+		audio.onerror = () => {
+			URL.revokeObjectURL(url);
+			resolve(0);
+		};
+		audio.src = url;
+	});
+}
+
+export async function splitAudioBlob(
+	blob: Blob,
+	segmentSeconds: number
+): Promise<Blob[]> {
+	const arrayBuffer = await blob.arrayBuffer();
+	const audioCtx = new AudioContext();
+	const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+	audioCtx.close();
+
+	const sampleRate = audioBuffer.sampleRate;
+	const totalSamples = audioBuffer.length;
+	const segmentSamples = Math.floor(segmentSeconds * sampleRate);
+	const segments: Blob[] = [];
+
+	let start = 0;
+	while (start < totalSamples) {
+		const end = Math.min(start + segmentSamples, totalSamples);
+		segments.push(encodeWavBlob(audioBuffer, start, end));
+		start = end;
+	}
+
+	return segments;
+}
+
+function encodeWavBlob(
+	buffer: AudioBuffer,
+	startSample: number,
+	endSample: number
+): Blob {
+	const numChannels = buffer.numberOfChannels;
+	const sampleRate = buffer.sampleRate;
+	const numSamples = endSample - startSample;
+	const bitsPerSample = 16;
+	const blockAlign = numChannels * (bitsPerSample / 8);
+	const byteRate = sampleRate * blockAlign;
+	const dataLength = numSamples * blockAlign;
+
+	const ab = new ArrayBuffer(44 + dataLength);
+	const view = new DataView(ab);
+
+	writeStr(view, 0, "RIFF");
+	view.setUint32(4, 36 + dataLength, true);
+	writeStr(view, 8, "WAVE");
+
+	writeStr(view, 12, "fmt ");
+	view.setUint32(16, 16, true);
+	view.setUint16(20, 1, true); // PCM
+	view.setUint16(22, numChannels, true);
+	view.setUint32(24, sampleRate, true);
+	view.setUint32(28, byteRate, true);
+	view.setUint16(32, blockAlign, true);
+	view.setUint16(34, bitsPerSample, true);
+
+	writeStr(view, 36, "data");
+	view.setUint32(40, dataLength, true);
+
+	let offset = 44;
+	for (let i = startSample; i < endSample; i++) {
+		for (let ch = 0; ch < numChannels; ch++) {
+			const s = buffer.getChannelData(ch)[i];
+			const clamped = Math.max(-1, Math.min(1, s));
+			view.setInt16(
+				offset,
+				clamped < 0 ? clamped * 32768 : clamped * 32767,
+				true
+			);
+			offset += 2;
+		}
+	}
+
+	return new Blob([ab], { type: "audio/wav" });
+}
+
+function writeStr(view: DataView, offset: number, str: string): void {
+	for (let i = 0; i < str.length; i++) {
+		view.setUint8(offset + i, str.charCodeAt(i));
+	}
+}

--- a/src/AudioSplitter.ts
+++ b/src/AudioSplitter.ts
@@ -3,9 +3,13 @@ export const SEGMENT_DURATION_SECONDS = 300; // 5 minutes
 
 // Silence detection constants (internal)
 const SPLIT_SEARCH_WINDOW_S = 30; // search up to 30 s before the target boundary
-const SILENCE_THRESHOLD_RMS = 0.015; // RMS below this = silence
 const MIN_SILENCE_S = 0.3; // silence must last at least 300 ms
 const RMS_WINDOW_S = 0.05; // 50 ms analysis windows
+
+export interface SplitPoint {
+	seconds: number; // boundary timestamp
+	silence: boolean; // true = snapped to a silence, false = exact boundary (fallback)
+}
 
 /**
  * Returns the audio duration and, if decoding was required to determine it
@@ -35,7 +39,8 @@ export async function probeAudio(
 export async function splitAudioBlob(
 	blob: Blob,
 	segmentSeconds: number,
-	preDecoded?: AudioBuffer
+	preDecoded?: AudioBuffer,
+	threshold = 0.015
 ): Promise<Blob[]> {
 	const audioBuffer = preDecoded ?? (await decodeAudio(blob));
 
@@ -47,11 +52,10 @@ export async function splitAudioBlob(
 	let start = 0;
 	while (start < totalSamples) {
 		const rawEnd = Math.min(start + segmentSamples, totalSamples);
-		// For all but the final segment, snap to a nearby silence
 		const end =
 			rawEnd === totalSamples
 				? totalSamples
-				: findSplitPoint(audioBuffer, rawEnd);
+				: findSplitPoint(audioBuffer, rawEnd, threshold);
 		segments.push(encodeWavBlob(audioBuffer, start, end));
 		start = end;
 	}
@@ -60,14 +64,67 @@ export async function splitAudioBlob(
 }
 
 /**
+ * Returns the split boundaries for a decoded AudioBuffer without encoding WAV.
+ * Used by the settings test UI to preview split points.
+ * Includes 0 (start) and buffer.duration (end) as the first and last entries.
+ */
+export function analyzeSplits(
+	buffer: AudioBuffer,
+	segmentSeconds: number,
+	threshold: number
+): SplitPoint[] {
+	const sr = buffer.sampleRate;
+	const totalSamples = buffer.length;
+	const segmentSamples = Math.floor(segmentSeconds * sr);
+	const points: SplitPoint[] = [{ seconds: 0, silence: false }];
+
+	let start = 0;
+	while (start < totalSamples) {
+		const rawEnd = Math.min(start + segmentSamples, totalSamples);
+		let end: number;
+		let silence: boolean;
+		if (rawEnd === totalSamples) {
+			end = totalSamples;
+			silence = false;
+		} else {
+			end = findSplitPoint(buffer, rawEnd, threshold);
+			silence = end !== rawEnd;
+		}
+		points.push({ seconds: end / sr, silence });
+		start = end;
+	}
+
+	return points;
+}
+
+/**
+ * Decodes a Blob and returns split boundary info. Used by the settings test UI.
+ */
+export async function analyzeAudioBlob(
+	blob: Blob,
+	segmentSeconds: number,
+	threshold: number
+): Promise<SplitPoint[]> {
+	const buffer = await decodeAudio(blob);
+	return analyzeSplits(buffer, segmentSeconds, threshold);
+}
+
+/**
  * Given a target split sample, scans the preceding SPLIT_SEARCH_WINDOW_S
  * seconds for the latest qualifying silence (RMS < threshold for >= MIN_SILENCE_S).
  * Returns the start sample of that silence, or targetSample as a fallback.
  */
-function findSplitPoint(buffer: AudioBuffer, targetSample: number): number {
+function findSplitPoint(
+	buffer: AudioBuffer,
+	targetSample: number,
+	threshold: number
+): number {
 	const sr = buffer.sampleRate;
 	const windowSamples = Math.floor(RMS_WINDOW_S * sr);
-	const searchStart = Math.max(0, targetSample - Math.floor(SPLIT_SEARCH_WINDOW_S * sr));
+	const searchStart = Math.max(
+		0,
+		targetSample - Math.floor(SPLIT_SEARCH_WINDOW_S * sr)
+	);
 	const minSilenceSamples = Math.floor(MIN_SILENCE_S * sr);
 	const numChannels = buffer.numberOfChannels;
 
@@ -77,7 +134,6 @@ function findSplitPoint(buffer: AudioBuffer, targetSample: number): number {
 	for (let pos = searchStart; pos < targetSample; pos += windowSamples) {
 		const wEnd = Math.min(pos + windowSamples, targetSample);
 
-		// RMS across all channels for this window
 		let sumSq = 0;
 		let n = 0;
 		for (let ch = 0; ch < numChannels; ch++) {
@@ -89,9 +145,8 @@ function findSplitPoint(buffer: AudioBuffer, targetSample: number): number {
 		}
 		const rms = n > 0 ? Math.sqrt(sumSq / n) : 0;
 
-		if (rms < SILENCE_THRESHOLD_RMS) {
+		if (rms < threshold) {
 			if (silenceRegionStart === -1) silenceRegionStart = pos;
-			// Record this as a candidate once silence is long enough
 			if (pos + windowSamples - silenceRegionStart >= minSilenceSamples) {
 				bestSplit = silenceRegionStart;
 			}

--- a/src/AudioSplitter.ts
+++ b/src/AudioSplitter.ts
@@ -1,6 +1,12 @@
 export const SPLIT_THRESHOLD_SECONDS = 600; // 10 minutes
 export const SEGMENT_DURATION_SECONDS = 300; // 5 minutes
 
+// Silence detection constants (internal)
+const SPLIT_SEARCH_WINDOW_S = 30; // search up to 30 s before the target boundary
+const SILENCE_THRESHOLD_RMS = 0.015; // RMS below this = silence
+const MIN_SILENCE_S = 0.3; // silence must last at least 300 ms
+const RMS_WINDOW_S = 0.05; // 50 ms analysis windows
+
 /**
  * Returns the audio duration and, if decoding was required to determine it
  * (e.g. WebM files from MediaRecorder which lack duration metadata), the
@@ -40,12 +46,61 @@ export async function splitAudioBlob(
 
 	let start = 0;
 	while (start < totalSamples) {
-		const end = Math.min(start + segmentSamples, totalSamples);
+		const rawEnd = Math.min(start + segmentSamples, totalSamples);
+		// For all but the final segment, snap to a nearby silence
+		const end =
+			rawEnd === totalSamples
+				? totalSamples
+				: findSplitPoint(audioBuffer, rawEnd);
 		segments.push(encodeWavBlob(audioBuffer, start, end));
 		start = end;
 	}
 
 	return segments;
+}
+
+/**
+ * Given a target split sample, scans the preceding SPLIT_SEARCH_WINDOW_S
+ * seconds for the latest qualifying silence (RMS < threshold for >= MIN_SILENCE_S).
+ * Returns the start sample of that silence, or targetSample as a fallback.
+ */
+function findSplitPoint(buffer: AudioBuffer, targetSample: number): number {
+	const sr = buffer.sampleRate;
+	const windowSamples = Math.floor(RMS_WINDOW_S * sr);
+	const searchStart = Math.max(0, targetSample - Math.floor(SPLIT_SEARCH_WINDOW_S * sr));
+	const minSilenceSamples = Math.floor(MIN_SILENCE_S * sr);
+	const numChannels = buffer.numberOfChannels;
+
+	let silenceRegionStart = -1;
+	let bestSplit = targetSample;
+
+	for (let pos = searchStart; pos < targetSample; pos += windowSamples) {
+		const wEnd = Math.min(pos + windowSamples, targetSample);
+
+		// RMS across all channels for this window
+		let sumSq = 0;
+		let n = 0;
+		for (let ch = 0; ch < numChannels; ch++) {
+			const data = buffer.getChannelData(ch);
+			for (let i = pos; i < wEnd; i++) {
+				sumSq += data[i] * data[i];
+				n++;
+			}
+		}
+		const rms = n > 0 ? Math.sqrt(sumSq / n) : 0;
+
+		if (rms < SILENCE_THRESHOLD_RMS) {
+			if (silenceRegionStart === -1) silenceRegionStart = pos;
+			// Record this as a candidate once silence is long enough
+			if (pos + windowSamples - silenceRegionStart >= minSilenceSamples) {
+				bestSplit = silenceRegionStart;
+			}
+		} else {
+			silenceRegionStart = -1;
+		}
+	}
+
+	return bestSplit;
 }
 
 async function getMetadataDuration(blob: Blob): Promise<number> {

--- a/src/AudioSplitter.ts
+++ b/src/AudioSplitter.ts
@@ -1,7 +1,54 @@
 export const SPLIT_THRESHOLD_SECONDS = 600; // 10 minutes
 export const SEGMENT_DURATION_SECONDS = 300; // 5 minutes
 
-export async function getAudioDuration(blob: Blob): Promise<number> {
+/**
+ * Returns the audio duration and, if decoding was required to determine it
+ * (e.g. WebM files from MediaRecorder which lack duration metadata), the
+ * pre-decoded AudioBuffer so callers can reuse it without a second decode.
+ */
+export async function probeAudio(
+	blob: Blob
+): Promise<{ duration: number; buffer: AudioBuffer | null }> {
+	const metaDuration = await getMetadataDuration(blob);
+	if (isFinite(metaDuration)) {
+		return { duration: metaDuration, buffer: null };
+	}
+	// Fallback: decode to get real duration (WebM from MediaRecorder reports Infinity)
+	try {
+		const buffer = await decodeAudio(blob);
+		return { duration: buffer.duration, buffer };
+	} catch {
+		return { duration: 0, buffer: null };
+	}
+}
+
+/**
+ * Splits a Blob into segments of segmentSeconds length, re-encoded as WAV.
+ * Pass a pre-decoded AudioBuffer to avoid decoding twice.
+ */
+export async function splitAudioBlob(
+	blob: Blob,
+	segmentSeconds: number,
+	preDecoded?: AudioBuffer
+): Promise<Blob[]> {
+	const audioBuffer = preDecoded ?? (await decodeAudio(blob));
+
+	const sampleRate = audioBuffer.sampleRate;
+	const totalSamples = audioBuffer.length;
+	const segmentSamples = Math.floor(segmentSeconds * sampleRate);
+	const segments: Blob[] = [];
+
+	let start = 0;
+	while (start < totalSamples) {
+		const end = Math.min(start + segmentSamples, totalSamples);
+		segments.push(encodeWavBlob(audioBuffer, start, end));
+		start = end;
+	}
+
+	return segments;
+}
+
+async function getMetadataDuration(blob: Blob): Promise<number> {
 	return new Promise((resolve) => {
 		const audio = document.createElement("audio");
 		const url = URL.createObjectURL(blob);
@@ -17,28 +64,12 @@ export async function getAudioDuration(blob: Blob): Promise<number> {
 	});
 }
 
-export async function splitAudioBlob(
-	blob: Blob,
-	segmentSeconds: number
-): Promise<Blob[]> {
+async function decodeAudio(blob: Blob): Promise<AudioBuffer> {
 	const arrayBuffer = await blob.arrayBuffer();
 	const audioCtx = new AudioContext();
-	const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
+	const buffer = await audioCtx.decodeAudioData(arrayBuffer);
 	audioCtx.close();
-
-	const sampleRate = audioBuffer.sampleRate;
-	const totalSamples = audioBuffer.length;
-	const segmentSamples = Math.floor(segmentSeconds * sampleRate);
-	const segments: Blob[] = [];
-
-	let start = 0;
-	while (start < totalSamples) {
-		const end = Math.min(start + segmentSamples, totalSamples);
-		segments.push(encodeWavBlob(audioBuffer, start, end));
-		start = end;
-	}
-
-	return segments;
+	return buffer;
 }
 
 function encodeWavBlob(

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -1,16 +1,16 @@
 import Whisper from "main";
-import { ButtonComponent, Modal, Setting } from "obsidian";
+import { ButtonComponent, Modal } from "obsidian";
 import { RecordingStatus } from "./StatusBar";
-import { AudioSourceMode } from "./SettingsManager";
 
 export class Controls extends Modal {
 	private plugin: Whisper;
-	private startButton: ButtonComponent;
+	private startMicButton: ButtonComponent;
+	private startSystemButton: ButtonComponent;
+	private startBothButton: ButtonComponent;
 	private pauseButton: ButtonComponent;
 	private stopButton: ButtonComponent;
 	private cancelButton: ButtonComponent;
 	private timerDisplay: HTMLElement;
-	private modeDisplay: HTMLElement;
 	private statusListener: () => void;
 
 	constructor(plugin: Whisper) {
@@ -25,20 +25,29 @@ export class Controls extends Modal {
 			this.updateTimerDisplay();
 		});
 
-		this.modeDisplay = this.contentEl.createEl("div", {
-			cls: "audio-mode-display",
-		});
-		this.updateModeDisplay();
-
 		const buttonGroupEl = this.contentEl.createEl("div", {
 			cls: "button-group",
 		});
 
-		this.startButton = new ButtonComponent(buttonGroupEl);
-		this.startButton
-			.setIcon("circle")
-			.setButtonText(" Record")
-			.onClick(() => this.plugin.startRecording())
+		this.startMicButton = new ButtonComponent(buttonGroupEl);
+		this.startMicButton
+			.setIcon("mic")
+			.setButtonText(" Mic")
+			.onClick(() => this.plugin.startRecording("microphone"))
+			.buttonEl.addClass("button-component");
+
+		this.startSystemButton = new ButtonComponent(buttonGroupEl);
+		this.startSystemButton
+			.setIcon("volume-up")
+			.setButtonText(" System")
+			.onClick(() => this.plugin.startRecording("system"))
+			.buttonEl.addClass("button-component");
+
+		this.startBothButton = new ButtonComponent(buttonGroupEl);
+		this.startBothButton
+			.setIcon("mic")
+			.setButtonText(" Both")
+			.onClick(() => this.plugin.startRecording("both"))
 			.buttonEl.addClass("button-component");
 
 		this.pauseButton = new ButtonComponent(buttonGroupEl);
@@ -71,14 +80,12 @@ export class Controls extends Modal {
 		this.statusListener = () => {
 			this.resetGUI();
 			this.updateTimerDisplay();
-			this.updateModeDisplay();
 		};
 	}
 
 	onOpen() {
 		this.resetGUI();
 		this.updateTimerDisplay();
-		this.updateModeDisplay();
 		this.plugin.statusBar.onChange(this.statusListener);
 	}
 
@@ -90,28 +97,25 @@ export class Controls extends Modal {
 		this.timerDisplay.textContent = this.plugin.timer.getFormattedTime();
 	}
 
-	private updateModeDisplay(): void {
-		const modeLabels: Record<AudioSourceMode, string> = {
-			microphone: "🎤 Microphone",
-			system: "🔊 System Audio",
-			both: "🎤🔊 Mic + System Audio",
-		};
-		const mode = this.plugin.recorder.getAudioSourceMode();
-		this.modeDisplay.textContent = `Source: ${modeLabels[mode]}`;
-		this.modeDisplay.style.opacity = "0.7";
-		this.modeDisplay.style.fontSize = "0.9em";
-		this.modeDisplay.style.marginBottom = "10px";
-	}
-
 	resetGUI() {
 		const status = this.plugin.statusBar.status;
 		const isIdle = status === RecordingStatus.Idle;
 		const isPaused = status === RecordingStatus.Paused;
 
-		this.startButton.buttonEl.style.display = isIdle ? "" : "none";
-		this.startButton.buttonEl.empty();
-		this.startButton.setIcon("circle");
-		this.startButton.buttonEl.appendText(" Record");
+		this.startMicButton.buttonEl.style.display = isIdle ? "" : "none";
+		this.startMicButton.buttonEl.empty();
+		this.startMicButton.setIcon("mic");
+		this.startMicButton.buttonEl.appendText(" Mic");
+
+		this.startSystemButton.buttonEl.style.display = isIdle ? "" : "none";
+		this.startSystemButton.buttonEl.empty();
+		this.startSystemButton.setIcon("volume-up");
+		this.startSystemButton.buttonEl.appendText(" System");
+
+		this.startBothButton.buttonEl.style.display = isIdle ? "" : "none";
+		this.startBothButton.buttonEl.empty();
+		this.startBothButton.setIcon("mic");
+		this.startBothButton.buttonEl.appendText(" Both");
 
 		this.pauseButton.buttonEl.style.display = isIdle ? "none" : "";
 		this.pauseButton.buttonEl.empty();

--- a/src/Controls.ts
+++ b/src/Controls.ts
@@ -1,6 +1,7 @@
 import Whisper from "main";
-import { ButtonComponent, Modal } from "obsidian";
+import { ButtonComponent, Modal, Setting } from "obsidian";
 import { RecordingStatus } from "./StatusBar";
+import { AudioSourceMode } from "./SettingsManager";
 
 export class Controls extends Modal {
 	private plugin: Whisper;
@@ -9,6 +10,7 @@ export class Controls extends Modal {
 	private stopButton: ButtonComponent;
 	private cancelButton: ButtonComponent;
 	private timerDisplay: HTMLElement;
+	private modeDisplay: HTMLElement;
 	private statusListener: () => void;
 
 	constructor(plugin: Whisper) {
@@ -22,6 +24,11 @@ export class Controls extends Modal {
 		this.plugin.timer.setOnUpdate(() => {
 			this.updateTimerDisplay();
 		});
+
+		this.modeDisplay = this.contentEl.createEl("div", {
+			cls: "audio-mode-display",
+		});
+		this.updateModeDisplay();
 
 		const buttonGroupEl = this.contentEl.createEl("div", {
 			cls: "button-group",
@@ -64,12 +71,14 @@ export class Controls extends Modal {
 		this.statusListener = () => {
 			this.resetGUI();
 			this.updateTimerDisplay();
+			this.updateModeDisplay();
 		};
 	}
 
 	onOpen() {
 		this.resetGUI();
 		this.updateTimerDisplay();
+		this.updateModeDisplay();
 		this.plugin.statusBar.onChange(this.statusListener);
 	}
 
@@ -79,6 +88,19 @@ export class Controls extends Modal {
 
 	updateTimerDisplay() {
 		this.timerDisplay.textContent = this.plugin.timer.getFormattedTime();
+	}
+
+	private updateModeDisplay(): void {
+		const modeLabels: Record<AudioSourceMode, string> = {
+			microphone: "🎤 Microphone",
+			system: "🔊 System Audio",
+			both: "🎤🔊 Mic + System Audio",
+		};
+		const mode = this.plugin.recorder.getAudioSourceMode();
+		this.modeDisplay.textContent = `Source: ${modeLabels[mode]}`;
+		this.modeDisplay.style.opacity = "0.7";
+		this.modeDisplay.style.fontSize = "0.9em";
+		this.modeDisplay.style.marginBottom = "10px";
 	}
 
 	resetGUI() {

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -52,6 +52,7 @@ export interface WhisperSettings {
 	// Advanced
 	debugMode: boolean;
 	concurrentTranscriptions: number;
+	silenceThreshold: number;
 }
 
 export interface PostProcessingSettings {
@@ -94,6 +95,7 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	noteTemplate: "![[{{audioFile}}]]\n{{transcription}}",
 	debugMode: false,
 	concurrentTranscriptions: 2,
+	silenceThreshold: 0.015,
 };
 
 export const DEFAULT_POST_PROCESSING: PostProcessingSettings = {

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -41,11 +41,11 @@ export interface WhisperSettings {
 	cursorContext: boolean;
 	// Recording
 	audioDeviceId: string;
-	audioSourceMode: AudioSourceMode;
 	saveAudioFile: boolean;
 	audioSavePath: string;
 	// Output
 	createNoteFile: boolean;
+	pasteAtCursor: boolean;
 	noteSavePath: string;
 	noteFilenameTemplate: string;
 	noteTemplate: string;
@@ -84,10 +84,10 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	responseFormat: "json",
 	cursorContext: false,
 	audioDeviceId: "default",
-	audioSourceMode: "microphone",
 	saveAudioFile: true,
 	audioSavePath: "",
 	createNoteFile: true,
+	pasteAtCursor: true,
 	noteSavePath: "",
 	noteFilenameTemplate: "{{datetime}}",
 	noteTemplate: "![[{{audioFile}}]]\n{{transcription}}",

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -51,6 +51,7 @@ export interface WhisperSettings {
 	noteTemplate: string;
 	// Advanced
 	debugMode: boolean;
+	concurrentTranscriptions: number;
 }
 
 export interface PostProcessingSettings {
@@ -92,6 +93,7 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	noteFilenameTemplate: "{{datetime}}",
 	noteTemplate: "![[{{audioFile}}]]\n{{transcription}}",
 	debugMode: false,
+	concurrentTranscriptions: 2,
 };
 
 export const DEFAULT_POST_PROCESSING: PostProcessingSettings = {

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -28,6 +28,8 @@ export interface ApiKeysSettings {
 	postProcessingApiKey: string;
 }
 
+export type AudioSourceMode = "microphone" | "system" | "both";
+
 export interface WhisperSettings {
 	// API
 	apiUrl: string;
@@ -39,6 +41,7 @@ export interface WhisperSettings {
 	cursorContext: boolean;
 	// Recording
 	audioDeviceId: string;
+	audioSourceMode: AudioSourceMode;
 	saveAudioFile: boolean;
 	audioSavePath: string;
 	// Output
@@ -81,6 +84,7 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	responseFormat: "json",
 	cursorContext: false,
 	audioDeviceId: "default",
+	audioSourceMode: "microphone",
 	saveAudioFile: true,
 	audioSavePath: "",
 	createNoteFile: true,

--- a/src/SourceSelectorModal.ts
+++ b/src/SourceSelectorModal.ts
@@ -6,6 +6,16 @@ export interface DesktopSource {
 	thumbnail: string;
 }
 
+function nativeImageToDataUrl(thumbnail: any): string {
+	if (typeof thumbnail === "string") {
+		return thumbnail;
+	}
+	if (thumbnail && typeof thumbnail.toDataURL === "function") {
+		return thumbnail.toDataURL();
+	}
+	return "";
+}
+
 export class SourceSelectorModal extends Modal {
 	private sources: DesktopSource[];
 	private selectedSource: DesktopSource | null = null;
@@ -47,15 +57,18 @@ export class SourceSelectorModal extends Modal {
 		for (const source of this.sources) {
 			const itemEl = listEl.createDiv({ cls: "source-item" });
 
+			const thumbnailUrl = nativeImageToDataUrl(source.thumbnail);
+			
 			const imgEl = itemEl.createEl("img", {
 				cls: "source-thumbnail",
-				attr: { src: source.thumbnail },
+				attr: thumbnailUrl ? { src: thumbnailUrl } : {},
 			});
 			imgEl.style.width = "200px";
 			imgEl.style.height = "125px";
 			imgEl.style.objectFit = "cover";
 			imgEl.style.borderRadius = "4px";
 			imgEl.style.border = "2px solid transparent";
+			imgEl.style.backgroundColor = "var(--background-modifier-border)";
 
 			itemEl.createEl("div", {
 				text: source.name,

--- a/src/SourceSelectorModal.ts
+++ b/src/SourceSelectorModal.ts
@@ -1,0 +1,95 @@
+import { App, Modal, Setting } from "obsidian";
+
+export interface DesktopSource {
+	id: string;
+	name: string;
+	thumbnail: string;
+}
+
+export class SourceSelectorModal extends Modal {
+	private sources: DesktopSource[];
+	private selectedSource: DesktopSource | null = null;
+	private resolvePromise: ((source: DesktopSource | null) => void) | null = null;
+
+	constructor(app: App, sources: DesktopSource[]) {
+		super(app);
+		this.sources = sources;
+		this.titleEl.setText("Select Audio Source");
+		this.modalEl.addClass("source-selector-modal");
+	}
+
+	static async selectSource(app: App, sources: DesktopSource[]): Promise<DesktopSource | null> {
+		return new Promise((resolve) => {
+			const modal = new SourceSelectorModal(app, sources);
+			modal.resolvePromise = resolve;
+			modal.open();
+		});
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+
+		if (this.sources.length === 0) {
+			contentEl.createEl("p", { text: "No capture sources found." });
+			new Setting(contentEl).addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => this.close())
+			);
+			return;
+		}
+
+		contentEl.createEl("p", {
+			text: "Select a window or screen to capture audio from. For best results, choose a window with audio playing.",
+			cls: "source-selector-hint",
+		});
+
+		const listEl = contentEl.createDiv({ cls: "source-list" });
+
+		for (const source of this.sources) {
+			const itemEl = listEl.createDiv({ cls: "source-item" });
+
+			const imgEl = itemEl.createEl("img", {
+				cls: "source-thumbnail",
+				attr: { src: source.thumbnail },
+			});
+			imgEl.style.width = "200px";
+			imgEl.style.height = "125px";
+			imgEl.style.objectFit = "cover";
+			imgEl.style.borderRadius = "4px";
+			imgEl.style.border = "2px solid transparent";
+
+			itemEl.createEl("div", {
+				text: source.name,
+				cls: "source-name",
+			});
+			itemEl.style.cursor = "pointer";
+			itemEl.style.textAlign = "center";
+			itemEl.style.margin = "10px";
+			itemEl.style.display = "inline-block";
+
+			itemEl.addEventListener("click", () => {
+				this.selectedSource = source;
+				this.close();
+			});
+
+			itemEl.addEventListener("mouseenter", () => {
+				imgEl.style.borderColor = "var(--interactive-accent)";
+			});
+			itemEl.addEventListener("mouseleave", () => {
+				imgEl.style.borderColor = "transparent";
+			});
+		}
+
+		new Setting(contentEl)
+			.addButton((btn) =>
+				btn.setButtonText("Cancel").onClick(() => this.close())
+			);
+	}
+
+	onClose() {
+		const { contentEl } = this;
+		contentEl.empty();
+		if (this.resolvePromise) {
+			this.resolvePromise(this.selectedSource);
+		}
+	}
+}

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -1,4 +1,5 @@
 import { Plugin } from "obsidian";
+import { AudioSourceMode } from "./SettingsManager";
 
 export enum RecordingStatus {
 	Idle = "idle",
@@ -12,10 +13,16 @@ export class StatusBar {
 	statusBarItem: HTMLElement | null = null;
 	status: RecordingStatus = RecordingStatus.Idle;
 	private listeners: Array<(status: RecordingStatus) => void> = [];
+	private currentMode: AudioSourceMode = "microphone";
 
 	constructor(plugin: Plugin) {
 		this.plugin = plugin;
 		this.statusBarItem = this.plugin.addStatusBarItem();
+		this.updateStatusBarItem();
+	}
+
+	setAudioSourceMode(mode: AudioSourceMode): void {
+		this.currentMode = mode;
 		this.updateStatusBarItem();
 	}
 
@@ -33,15 +40,28 @@ export class StatusBar {
 		this.listeners.forEach((fn) => fn(status));
 	}
 
+	private getModeIndicator(): string {
+		switch (this.currentMode) {
+			case "system":
+				return "🔊 ";
+			case "both":
+				return "🎤🔊 ";
+			case "microphone":
+			default:
+				return "🎤 ";
+		}
+	}
+
 	updateStatusBarItem() {
 		if (this.statusBarItem) {
+			const modeIcon = this.getModeIndicator();
 			switch (this.status) {
 				case RecordingStatus.Recording:
-					this.statusBarItem.textContent = "Recording...";
+					this.statusBarItem.textContent = `${modeIcon}Recording...`;
 					this.statusBarItem.style.color = "red";
 					break;
 				case RecordingStatus.Paused:
-					this.statusBarItem.textContent = "Paused";
+					this.statusBarItem.textContent = `${modeIcon}Paused`;
 					this.statusBarItem.style.color = "yellow";
 					break;
 				case RecordingStatus.Processing:
@@ -50,7 +70,7 @@ export class StatusBar {
 					break;
 				case RecordingStatus.Idle:
 				default:
-					this.statusBarItem.textContent = "Whisper Idle";
+					this.statusBarItem.textContent = `${modeIcon}Whisper`;
 					this.statusBarItem.style.color = "green";
 					break;
 			}

--- a/src/StatusBar.ts
+++ b/src/StatusBar.ts
@@ -1,5 +1,4 @@
 import { Plugin } from "obsidian";
-import { AudioSourceMode } from "./SettingsManager";
 
 export enum RecordingStatus {
 	Idle = "idle",
@@ -13,16 +12,10 @@ export class StatusBar {
 	statusBarItem: HTMLElement | null = null;
 	status: RecordingStatus = RecordingStatus.Idle;
 	private listeners: Array<(status: RecordingStatus) => void> = [];
-	private currentMode: AudioSourceMode = "microphone";
 
 	constructor(plugin: Plugin) {
 		this.plugin = plugin;
 		this.statusBarItem = this.plugin.addStatusBarItem();
-		this.updateStatusBarItem();
-	}
-
-	setAudioSourceMode(mode: AudioSourceMode): void {
-		this.currentMode = mode;
 		this.updateStatusBarItem();
 	}
 
@@ -40,28 +33,15 @@ export class StatusBar {
 		this.listeners.forEach((fn) => fn(status));
 	}
 
-	private getModeIndicator(): string {
-		switch (this.currentMode) {
-			case "system":
-				return "🔊 ";
-			case "both":
-				return "🎤🔊 ";
-			case "microphone":
-			default:
-				return "🎤 ";
-		}
-	}
-
 	updateStatusBarItem() {
 		if (this.statusBarItem) {
-			const modeIcon = this.getModeIndicator();
 			switch (this.status) {
 				case RecordingStatus.Recording:
-					this.statusBarItem.textContent = `${modeIcon}Recording...`;
+					this.statusBarItem.textContent = "Recording...";
 					this.statusBarItem.style.color = "red";
 					break;
 				case RecordingStatus.Paused:
-					this.statusBarItem.textContent = `${modeIcon}Paused`;
+					this.statusBarItem.textContent = "Paused";
 					this.statusBarItem.style.color = "yellow";
 					break;
 				case RecordingStatus.Processing:
@@ -70,7 +50,7 @@ export class StatusBar {
 					break;
 				case RecordingStatus.Idle:
 				default:
-					this.statusBarItem.textContent = `${modeIcon}Whisper`;
+					this.statusBarItem.textContent = "Whisper";
 					this.statusBarItem.style.color = "green";
 					break;
 			}

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -77,6 +77,14 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		new Setting(containerEl).setName("Advanced").setHeading();
 		this.createDebugModeToggleSetting();
 
+		// Expert settings (collapsible)
+		const details = containerEl.createEl("details");
+		details.createEl("summary", {
+			text: "Expert settings",
+			cls: "whisper-expert-summary",
+		});
+		this.createConcurrentTranscriptionsSetting(details);
+
 		// Restore scroll position after re-render to prevent jumping
 		containerEl.scrollTop = scrollTop;
 	}
@@ -629,6 +637,28 @@ export class WhisperSettingsTab extends PluginSettingTab {
 						await this.save();
 					});
 			});
+	}
+
+	private createConcurrentTranscriptionsSetting(
+		container: HTMLElement
+	): void {
+		new Setting(container)
+			.setName("Concurrent transcription requests")
+			.setDesc(
+				"Number of audio segments sent to the API in parallel when splitting long recordings."
+			)
+			.addSlider((slider) =>
+				slider
+					.setLimits(1, 5, 1)
+					.setValue(this.plugin.settings.concurrentTranscriptions)
+					.setDynamicTooltip()
+					.onChange(async (value) => {
+						this.plugin.settings.concurrentTranscriptions = value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					})
+			);
 	}
 
 	private createDebugModeToggleSetting(): void {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -1,6 +1,11 @@
 import Whisper from "main";
 import { App, PluginSettingTab, Setting } from "obsidian";
 import {
+	analyzeAudioBlob,
+	SEGMENT_DURATION_SECONDS,
+	SplitPoint,
+} from "./AudioSplitter";
+import {
 	SettingsManager,
 	PostProcessingProvider,
 	PROVIDER_URLS,
@@ -84,6 +89,8 @@ export class WhisperSettingsTab extends PluginSettingTab {
 			cls: "whisper-expert-summary",
 		});
 		this.createConcurrentTranscriptionsSetting(details);
+		this.createSilenceThresholdSetting(details);
+		this.createSplitTestSetting(details);
 
 		// Restore scroll position after re-render to prevent jumping
 		containerEl.scrollTop = scrollTop;
@@ -661,6 +668,79 @@ export class WhisperSettingsTab extends PluginSettingTab {
 			);
 	}
 
+	private createSilenceThresholdSetting(container: HTMLElement): void {
+		new Setting(container)
+			.setName("Silence threshold")
+			.setDesc(
+				"RMS amplitude below which audio is considered silence (0.001 – 0.1). Lower = more sensitive to quiet pauses."
+			)
+			.addText((text) => {
+				text.setValue(
+					String(this.plugin.settings.silenceThreshold)
+				);
+				text.inputEl.type = "number";
+				text.inputEl.min = "0.001";
+				text.inputEl.max = "0.1";
+				text.inputEl.step = "0.001";
+				text.onChange(async (value) => {
+					const num = parseFloat(value);
+					if (!isNaN(num) && num >= 0.001 && num <= 0.1) {
+						this.plugin.settings.silenceThreshold = num;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					}
+				});
+			});
+	}
+
+	private createSplitTestSetting(container: HTMLElement): void {
+		const resultsEl = container.createDiv({
+			cls: "whisper-split-results",
+		});
+
+		new Setting(container)
+			.setName("Test split points")
+			.setDesc(
+				"Load an audio file to preview where it would be split with the current threshold."
+			)
+			.addButton((btn) => {
+				btn.setButtonText("Choose file…").onClick(() => {
+					const input = document.createElement("input");
+					input.type = "file";
+					input.accept =
+						"audio/*,video/*,.mp4,.m4a,.wav,.webm,.ogg,.mp3";
+					input.onchange = async () => {
+						const file = input.files?.[0];
+						if (!file) return;
+						resultsEl.empty();
+						resultsEl.setText("Analyzing…");
+						try {
+							const blob = new Blob(
+								[await file.arrayBuffer()],
+								{ type: file.type }
+							);
+							const points = await analyzeAudioBlob(
+								blob,
+								SEGMENT_DURATION_SECONDS,
+								this.plugin.settings.silenceThreshold
+							);
+							renderSplitResults(resultsEl, points, file.name);
+						} catch (err) {
+							resultsEl.empty();
+							resultsEl.setText(
+								"Failed to analyze: " +
+									(err instanceof Error
+										? err.message
+										: String(err))
+							);
+						}
+					};
+					input.click();
+				});
+			});
+	}
+
 	private createDebugModeToggleSetting(): void {
 		new Setting(this.containerEl)
 			.setName("Debug mode")
@@ -675,5 +755,38 @@ export class WhisperSettingsTab extends PluginSettingTab {
 						);
 					});
 			});
+	}
+}
+
+function fmtTime(seconds: number): string {
+	const m = Math.floor(seconds / 60);
+	const s = Math.floor(seconds % 60);
+	return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+function renderSplitResults(
+	el: HTMLElement,
+	points: SplitPoint[],
+	fileName: string
+): void {
+	el.empty();
+	const segmentCount = points.length - 1;
+	const totalSeconds = points[points.length - 1].seconds;
+	el.createEl("p", {
+		text: `${segmentCount} segment${segmentCount !== 1 ? "s" : ""} — ${fmtTime(totalSeconds)} total — ${fileName}`,
+	});
+	const list = el.createEl("ul");
+	for (let i = 0; i < segmentCount; i++) {
+		const start = points[i].seconds;
+		const end = points[i + 1].seconds;
+		const label =
+			i === segmentCount - 1
+				? "(end)"
+				: points[i + 1].silence
+				? "(silence)"
+				: "(exact boundary)";
+		list.createEl("li", {
+			text: `${i + 1}: ${fmtTime(start)} → ${fmtTime(end)}  ${label}`,
+		});
 	}
 }

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -5,7 +5,6 @@ import {
 	PostProcessingProvider,
 	PROVIDER_URLS,
 	PROVIDER_DEFAULT_MODELS,
-	AudioSourceMode,
 } from "./SettingsManager";
 
 export class WhisperSettingsTab extends PluginSettingTab {
@@ -42,19 +41,9 @@ export class WhisperSettingsTab extends PluginSettingTab {
 
 		// --- Recording ---
 		new Setting(containerEl).setName("Recording").setHeading();
-		void this.createAudioSourceModeSetting();
-		if (
-			this.plugin.settings.audioSourceMode === "microphone" ||
-			this.plugin.settings.audioSourceMode === "both"
-		) {
-			void this.createAudioDeviceSetting();
-		}
-		if (
-			this.plugin.settings.audioSourceMode === "system" ||
-			this.plugin.settings.audioSourceMode === "both"
-		) {
-			this.createSystemAudioGuideSetting();
-		}
+		this.createKeybindsInfoSetting();
+		void this.createAudioDeviceSetting();
+		this.createSystemAudioGuideSetting();
 		this.createSaveAudioFileToggleSetting();
 		if (this.plugin.settings.saveAudioFile) {
 			this.createSaveAudioFilePathSetting();
@@ -68,6 +57,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 			this.createNoteFilenameTemplateSetting();
 			this.createNoteTemplateSetting();
 		}
+		this.createPasteAtCursorSetting();
 
 		// --- Post-Processing ---
 		new Setting(containerEl).setName("Post-processing").setHeading();
@@ -288,35 +278,16 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		});
 	}
 
-	private async createAudioSourceModeSetting(): Promise<void> {
-		const modeOptions: Record<AudioSourceMode, string> = {
-			microphone: "Microphone",
-			system: "System Audio (speakers/headphones)",
-			both: "Microphone + System Audio",
-		};
-
+	private createKeybindsInfoSetting(): void {
 		new Setting(this.containerEl)
-			.setName("Audio Source")
+			.setName("Recording Keybinds")
 			.setDesc(
-				"Choose what audio to capture for transcription. System audio lets you transcribe online meetings, videos, and other app audio."
-			)
-			.addDropdown((dropdown) => {
-				for (const [value, label] of Object.entries(modeOptions)) {
-					dropdown.addOption(value, label);
-				}
-				dropdown
-					.setValue(this.plugin.settings.audioSourceMode)
-					.onChange(async (value) => {
-						const mode = value as AudioSourceMode;
-						this.plugin.settings.audioSourceMode = mode;
-						await this.settingsManager.saveSettings(
-							this.plugin.settings
-						);
-						this.plugin.recorder.setAudioSourceMode(mode);
-						this.plugin.statusBar.setAudioSourceMode(mode);
-						this.display();
-					});
-			});
+				"Use different hotkeys to choose your audio source:\n" +
+				"• Alt+Q — Record Microphone + System Audio (meetings)\n" +
+				"• Alt+Shift+Q — Record Microphone only\n" +
+				"• Alt+Ctrl+Q — Record System Audio only (videos, music)\n\n" +
+				"Customize these in Settings → Hotkeys"
+			);
 	}
 
 	private createSystemAudioGuideSetting(): void {
@@ -405,6 +376,20 @@ export class WhisperSettingsTab extends PluginSettingTab {
 						}
 						await this.save();
 						this.display();
+					});
+			});
+	}
+
+	private createPasteAtCursorSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Paste at cursor")
+			.setDesc("Also insert the transcription at your cursor position in the active note")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.pasteAtCursor)
+					.onChange(async (value) => {
+						this.plugin.settings.pasteAtCursor = value;
+						await this.save();
 					});
 			});
 	}

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -5,6 +5,7 @@ import {
 	PostProcessingProvider,
 	PROVIDER_URLS,
 	PROVIDER_DEFAULT_MODELS,
+	AudioSourceMode,
 } from "./SettingsManager";
 
 export class WhisperSettingsTab extends PluginSettingTab {
@@ -41,8 +42,19 @@ export class WhisperSettingsTab extends PluginSettingTab {
 
 		// --- Recording ---
 		new Setting(containerEl).setName("Recording").setHeading();
-		// async — populates device dropdown after enumeration completes
-		void this.createAudioDeviceSetting();
+		void this.createAudioSourceModeSetting();
+		if (
+			this.plugin.settings.audioSourceMode === "microphone" ||
+			this.plugin.settings.audioSourceMode === "both"
+		) {
+			void this.createAudioDeviceSetting();
+		}
+		if (
+			this.plugin.settings.audioSourceMode === "system" ||
+			this.plugin.settings.audioSourceMode === "both"
+		) {
+			this.createSystemAudioGuideSetting();
+		}
 		this.createSaveAudioFileToggleSetting();
 		if (this.plugin.settings.saveAudioFile) {
 			this.createSaveAudioFilePathSetting();
@@ -274,6 +286,45 @@ export class WhisperSettingsTab extends PluginSettingTab {
 				);
 			});
 		});
+	}
+
+	private async createAudioSourceModeSetting(): Promise<void> {
+		const modeOptions: Record<AudioSourceMode, string> = {
+			microphone: "Microphone",
+			system: "System Audio (speakers/headphones)",
+			both: "Microphone + System Audio",
+		};
+
+		new Setting(this.containerEl)
+			.setName("Audio Source")
+			.setDesc(
+				"Choose what audio to capture for transcription. System audio lets you transcribe online meetings, videos, and other app audio."
+			)
+			.addDropdown((dropdown) => {
+				for (const [value, label] of Object.entries(modeOptions)) {
+					dropdown.addOption(value, label);
+				}
+				dropdown
+					.setValue(this.plugin.settings.audioSourceMode)
+					.onChange(async (value) => {
+						const mode = value as AudioSourceMode;
+						this.plugin.settings.audioSourceMode = mode;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+						this.plugin.recorder.setAudioSourceMode(mode);
+						this.plugin.statusBar.setAudioSourceMode(mode);
+						this.display();
+					});
+			});
+	}
+
+	private createSystemAudioGuideSetting(): void {
+		new Setting(this.containerEl)
+			.setName("System Audio Capture")
+			.setDesc(
+				"When recording, you'll be prompted to select a tab, window, or screen to capture audio from. For online meetings, select the meeting tab/window. Tip: On macOS, system audio capture requires macOS 13+ or a virtual audio device like BlackHole."
+			);
 	}
 
 	private createSaveAudioFileToggleSetting(): void {

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -323,7 +323,9 @@ export class WhisperSettingsTab extends PluginSettingTab {
 		new Setting(this.containerEl)
 			.setName("System Audio Capture")
 			.setDesc(
-				"When recording, you'll be prompted to select a tab, window, or screen to capture audio from. For online meetings, select the meeting tab/window. Tip: On macOS, system audio capture requires macOS 13+ or a virtual audio device like BlackHole."
+				"When recording, select a tab/window with audio playing. " +
+				"If the dialog doesn't appear or shows 'not supported', your Obsidian version may not support this feature. " +
+				"Alternative: Install a virtual audio device (VB-Audio Cable on Windows, BlackHole on macOS) and select it as your microphone input."
 			);
 	}
 

--- a/styles.css
+++ b/styles.css
@@ -36,3 +36,43 @@
 	width: 14px;
 	height: 14px;
 }
+
+.source-selector-modal .modal-content {
+	max-width: 700px;
+}
+
+.source-selector-modal .source-selector-hint {
+	margin-bottom: 16px;
+	opacity: 0.8;
+}
+
+.source-selector-modal .source-list {
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: center;
+	max-height: 400px;
+	overflow-y: auto;
+}
+
+.source-selector-modal .source-item {
+	padding: 8px;
+	border-radius: 8px;
+	transition: background-color 0.2s;
+}
+
+.source-selector-modal .source-item:hover {
+	background-color: var(--background-modifier-hover);
+}
+
+.source-selector-modal .source-name {
+	font-size: var(--font-ui-smaller);
+	margin-top: 6px;
+	max-width: 200px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.audio-mode-display {
+	text-align: center;
+}


### PR DESCRIPTION
## Summary

- Audio files longer than 10 minutes are automatically split into ~5-minute segments before transcription — applies to live recordings, context menu, and file upload
- Split points snap to the nearest silence within 30 s of the boundary (RMS-based detection), falling back to exact boundaries if no silence is found
- WebM files from MediaRecorder (which report `Infinity` duration in metadata) are handled via `AudioContext.decodeAudioData` fallback — decoded buffer is cached to avoid a second decode when splitting
- Segments are transcribed using a worker pool (default 2 concurrent), so a free worker picks up the next segment immediately
- All segment transcriptions are combined into a single output note

## New settings (Expert settings, collapsible)

| Setting | Default | Description |
|---|---|---|
| Concurrent transcription requests | 2 | Worker pool size (1–5) |
| Silence threshold | 0.015 | RMS amplitude below which audio counts as silence (0.001–0.1) |

## Test split points UI

Expert settings includes a "Choose file…" button that decodes any audio file and previews exactly where it would be split — showing timestamps and whether each boundary landed on silence or the exact fallback.

## Test plan

- [ ] Record a short clip (< 10 min) — should transcribe identically to before, no splitting notices
- [ ] Load a file > 10 min via context menu — should see "Splitting audio…" → per-segment progress notices → single combined note
- [ ] Adjust silence threshold in Expert settings and use the test button to verify split points shift accordingly
- [ ] Set concurrency to 1 and confirm sequential behavior; set to 3 and confirm parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)