### PR TITLE
fix: stop pasting transcript to active editor when creating a note

### DIFF
--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -258,11 +258,19 @@ export class AudioHandler {
 				);
 			}
 
-			// Paste into the editor captured at the start of this invocation,
-			// not whichever editor happens to be active now — otherwise a
-			// concurrent recording (or a manual click on a freshly created
-			// note) would re-route this paste to the wrong note.
-			if (targetEditor) {
+			// In dictation mode (createNoteFile off) the cursor paste is the
+			// only output. When createNoteFile is on, paste is opt-in via
+			// pasteAtCursorWhenCreatingNote — defaulting it off avoids the
+			// transcript landing twice (in the new note AND in whatever note
+			// happens to be open).
+			//
+			// The editor reference is the one captured at the start of this
+			// invocation, so a concurrent recording (or a manual click into
+			// another note) can't re-route this paste mid-flow.
+			const shouldPaste =
+				!this.plugin.settings.createNoteFile ||
+				this.plugin.settings.pasteAtCursorWhenCreatingNote;
+			if (shouldPaste && targetEditor) {
 				const cursorPosition = targetEditor.getCursor();
 				targetEditor.replaceRange(outputText, cursorPosition);
 

--- a/src/AudioHandler.ts
+++ b/src/AudioHandler.ts
@@ -37,6 +37,16 @@ export class AudioHandler {
 	}
 
 	async sendAudioData(blob: Blob, fileName: string): Promise<void> {
+		// Capture the active editor once, up front, so the paste at the end of
+		// this flow lands in the editor that was foreground when the user
+		// stopped *this* recording. Without this, a second recording started
+		// while this one is post-processing can shift the workspace's active
+		// editor (e.g. user clicks a freshly created note) and re-route this
+		// recording's paste to the wrong note.
+		const targetEditor =
+			this.plugin.app.workspace.getActiveViewOfType(MarkdownView)
+				?.editor ?? null;
+
 		// Get the base file name without extension
 		const baseFileName = getBaseFileName(fileName);
 
@@ -81,15 +91,9 @@ export class AudioHandler {
 		}
 
 		let prompt = this.plugin.settings.prompt || "";
-		if (this.plugin.settings.cursorContext) {
-			const editor =
-				this.plugin.app.workspace.getActiveViewOfType(
-					MarkdownView
-				)?.editor;
-			if (editor) {
-				const context = getCursorContext(editor);
-				prompt = prompt ? `${prompt}\n${context}` : context;
-			}
+		if (this.plugin.settings.cursorContext && targetEditor) {
+			const context = getCursorContext(targetEditor);
+			prompt = prompt ? `${prompt}\n${context}` : context;
 		}
 		if (prompt) formData.append("prompt", prompt);
 
@@ -254,20 +258,19 @@ export class AudioHandler {
 				);
 			}
 
-			// Paste at cursor if there's an active editor
-			const editor =
-				this.plugin.app.workspace.getActiveViewOfType(
-					MarkdownView
-				)?.editor;
-			if (editor) {
-				const cursorPosition = editor.getCursor();
-				editor.replaceRange(outputText, cursorPosition);
+			// Paste into the editor captured at the start of this invocation,
+			// not whichever editor happens to be active now — otherwise a
+			// concurrent recording (or a manual click on a freshly created
+			// note) would re-route this paste to the wrong note.
+			if (targetEditor) {
+				const cursorPosition = targetEditor.getCursor();
+				targetEditor.replaceRange(outputText, cursorPosition);
 
 				const newPosition = {
 					line: cursorPosition.line,
 					ch: cursorPosition.ch + outputText.length,
 				};
-				editor.setCursor(newPosition);
+				targetEditor.setCursor(newPosition);
 			}
 
 			new Notice("Transcription complete");

--- a/src/SettingsManager.ts
+++ b/src/SettingsManager.ts
@@ -46,6 +46,7 @@ export interface WhisperSettings {
 	noteSavePath: string;
 	noteFilenameTemplate: string;
 	noteTemplate: string;
+	pasteAtCursorWhenCreatingNote: boolean;
 	// Advanced
 	debugMode: boolean;
 }
@@ -87,6 +88,7 @@ export const DEFAULT_WHISPER: WhisperSettings = {
 	noteSavePath: "",
 	noteFilenameTemplate: "{{datetime}}",
 	noteTemplate: "![[{{audioFile}}]]\n{{transcription}}",
+	pasteAtCursorWhenCreatingNote: false,
 	debugMode: false,
 };
 

--- a/src/WhisperSettingsTab.ts
+++ b/src/WhisperSettingsTab.ts
@@ -55,6 +55,7 @@ export class WhisperSettingsTab extends PluginSettingTab {
 			this.createNewFilePathSetting();
 			this.createNoteFilenameTemplateSetting();
 			this.createNoteTemplateSetting();
+			this.createPasteAtCursorWhenCreatingNoteSetting();
 		}
 
 		// --- Post-Processing ---
@@ -406,6 +407,27 @@ export class WhisperSettingsTab extends PluginSettingTab {
 					});
 				text.inputEl.rows = 4;
 				text.inputEl.cols = 50;
+			});
+	}
+
+	private createPasteAtCursorWhenCreatingNoteSetting(): void {
+		new Setting(this.containerEl)
+			.setName("Also paste at cursor")
+			.setDesc(
+				"When creating a note file, also paste the transcript at the cursor in the active editor. Off by default to avoid duplicate output."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(
+						this.plugin.settings.pasteAtCursorWhenCreatingNote
+					)
+					.onChange(async (value) => {
+						this.plugin.settings.pasteAtCursorWhenCreatingNote =
+							value;
+						await this.settingsManager.saveSettings(
+							this.plugin.settings
+						);
+					});
 			});
 	}
 

--- a/tests/AudioHandler.test.ts
+++ b/tests/AudioHandler.test.ts
@@ -236,23 +236,33 @@ describe("isDefaultApi — API key requirement", () => {
 	});
 });
 
-describe("#115 — createNoteFile does not navigate away", () => {
-	// Simulates the output behavior of sendAudioData:
-	// - always paste at cursor in the active editor
-	// - optionally save a note file in the background (no navigation)
+describe("output mode: createNoteFile + pasteAtCursorWhenCreatingNote", () => {
+	// Output modes:
+	// - createNoteFile off: pure dictation — paste at the cursor in the active editor.
+	// - createNoteFile on, pasteAtCursorWhenCreatingNote off (default):
+	//     only write the new note. Don't touch the open editor.
+	// - createNoteFile on, pasteAtCursorWhenCreatingNote on:
+	//     write the new note AND also paste at cursor.
+	// The default avoids the transcript landing twice (in the new note AND in
+	// whatever note happens to be open), which is the bug from PR #115.
 
 	function simulateTranscriptionOutput(
-		settings: { createNoteFile: boolean },
+		settings: {
+			createNoteFile: boolean;
+			pasteAtCursorWhenCreatingNote: boolean;
+		},
 		hasActiveEditor: boolean
 	) {
 		const actions: string[] = [];
 
 		if (settings.createNoteFile) {
 			actions.push("create-note-file");
-			// openLinkText was removed — no navigation
 		}
 
-		if (hasActiveEditor) {
+		const shouldPaste =
+			!settings.createNoteFile ||
+			settings.pasteAtCursorWhenCreatingNote;
+		if (shouldPaste && hasActiveEditor) {
 			actions.push("paste-at-cursor");
 		}
 
@@ -261,34 +271,50 @@ describe("#115 — createNoteFile does not navigate away", () => {
 
 	it("pastes at cursor when createNoteFile is off", () => {
 		const actions = simulateTranscriptionOutput(
-			{ createNoteFile: false },
+			{ createNoteFile: false, pasteAtCursorWhenCreatingNote: false },
 			true
 		);
 		expect(actions).toEqual(["paste-at-cursor"]);
 	});
 
-	it("pastes at cursor AND creates note file when both enabled", () => {
+	it("only creates a note file by default when createNoteFile is on", () => {
 		const actions = simulateTranscriptionOutput(
-			{ createNoteFile: true },
+			{ createNoteFile: true, pasteAtCursorWhenCreatingNote: false },
+			true
+		);
+		expect(actions).toEqual(["create-note-file"]);
+	});
+
+	it("creates a note file AND pastes when the opt-in is on", () => {
+		const actions = simulateTranscriptionOutput(
+			{ createNoteFile: true, pasteAtCursorWhenCreatingNote: true },
 			true
 		);
 		expect(actions).toEqual(["create-note-file", "paste-at-cursor"]);
 	});
 
-	it("does not navigate away when creating note file", () => {
+	it("does not navigate away when creating a note file", () => {
 		const actions = simulateTranscriptionOutput(
-			{ createNoteFile: true },
+			{ createNoteFile: true, pasteAtCursorWhenCreatingNote: false },
 			true
 		);
 		expect(actions).not.toContain("navigate-to-note");
 	});
 
-	it("only creates note file when no active editor", () => {
+	it("only creates a note file when no active editor (paste opt-in has nowhere to go)", () => {
 		const actions = simulateTranscriptionOutput(
-			{ createNoteFile: true },
+			{ createNoteFile: true, pasteAtCursorWhenCreatingNote: true },
 			false
 		);
 		expect(actions).toEqual(["create-note-file"]);
+	});
+
+	it("does nothing visible when createNoteFile is off and no editor is open", () => {
+		const actions = simulateTranscriptionOutput(
+			{ createNoteFile: false, pasteAtCursorWhenCreatingNote: false },
+			false
+		);
+		expect(actions).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
## Summary

Two related fixes around the paste-at-cursor side effect of `sendAudioData`:

1. **Decouple \"Create note file\" from \"paste at cursor.\"** Since #115 (\"always paste at cursor, save note file in background\"), turning on Create note file means the transcript lands **twice**: once in the new note (from `vault.create`) and once at the cursor in whatever editor is currently foreground. When the foreground editor is a recurring note (a daily log, etc.), two recordings in close succession both leak their transcript into it — which reads as the recordings' content being swapped or merged across notes. Add a new `pasteAtCursorWhenCreatingNote` setting (default **off**) that gates the paste; flipping it on restores the #115 combined behavior explicitly.

2. **Capture the active editor up front in `sendAudioData`.** The old code read `getActiveViewOfType(MarkdownView)?.editor` again right before paste — after ~10–20s of transcription + post-processing + title-gen awaits. If a second recording was started during that window, both concurrent `sendAudioData` invocations resolved their paste target to whichever editor happened to be foreground at paste-time, not the editor that was active when each individual recording was stopped. Capture once at the top of `sendAudioData` and reuse for both cursor-context and paste-at-cursor.

## Why the default is off

\"Create note file\" reads to most users as \"this recording becomes a separate note,\" not \"... and also gets pasted into wherever I happen to be.\" The duplicate output is surprising and easy to mistake for a bug (originally reported as \"two recordings swap data across notes\"). Users who liked the combined dictation+file behavior can opt back in with one toggle.

If maintainers prefer backward-compat, happy to flip the default to `true` — let me know.

## Behavior matrix

| createNoteFile | pasteAtCursorWhenCreatingNote | Result |
|---|---|---|
| off | (n/a) | Pure dictation: paste at cursor only (unchanged) |
| on | off (new default) | Only writes the new note |
| on | on | Writes the new note **and** pastes at cursor (= old #115 behavior) |

## Changes

- `src/AudioHandler.ts` — capture `targetEditor` once at the top of `sendAudioData`; reuse for both cursor-context prompt and paste-at-cursor; gate paste on `!createNoteFile || pasteAtCursorWhenCreatingNote`.
- `src/SettingsManager.ts` — add `pasteAtCursorWhenCreatingNote: boolean` (default `false`).
- `src/WhisperSettingsTab.ts` — new \"Also paste at cursor\" toggle under Output, shown only when Create note file is on.
- `tests/AudioHandler.test.ts` — rewrite the #115 output-mode tests to cover the three combinations.

Build + 71 tests pass.